### PR TITLE
Fix broken images in /blog/tags/... plus other tag issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       - working-directory: website
         run: yarn
       - working-directory: website
+        run: yarn check-thumbnails
+      - working-directory: website
         run: |
           yarn fmt
           git diff --exit-code

--- a/website/blog/2023-10-31-mlflow-docs-overhaul.md
+++ b/website/blog/2023-10-31-mlflow-docs-overhaul.md
@@ -3,7 +3,7 @@ title: MLflow Docs Overhaul
 tags: [docs]
 slug: mlflow-docs-overhaul
 authors: [mlflow-maintainers]
-thumbnail: img/blog/docs-overhaul.png
+thumbnail: /img/blog/docs-overhaul.png
 ---
 
 The MLflow Documentation is getting an upgrade.

--- a/website/blog/2023-11-30-mlflow-autolog/index.md
+++ b/website/blog/2023-11-30-mlflow-autolog/index.md
@@ -3,7 +3,7 @@ title: "Automatic Metric, Parameter, and Artifact Logging with mlflow.autolog"
 slug: mlflow-autolog
 tags: [autolog]
 authors: [daniel-liden]
-thumbnail: img/blog/mlflow-autolog.png
+thumbnail: /img/blog/mlflow-autolog.png
 ---
 
 Looking to learn more about the autologging functionality included in MLflow? Look no further than this primer on the basics of using this powerful and time-saving feature!

--- a/website/blog/2023-12-01-ai-gateway-rename.md
+++ b/website/blog/2023-12-01-ai-gateway-rename.md
@@ -3,7 +3,7 @@ title: MLflow AI Gateway renamed to MLflow Deployments for LLMs
 tags: [ai]
 slug: ai-gateway-rename
 authors: [mlflow-maintainers]
-thumbnail: img/blog/ai-gateway.png
+thumbnail: /img/blog/ai-gateway.png
 ---
 
 If you are currently using the MLflow AI Gateway, please read this in full to get critically important information about this feature!

--- a/website/blog/2024-01-23-custom-pyfunc/index.md
+++ b/website/blog/2024-01-23-custom-pyfunc/index.md
@@ -4,7 +4,7 @@ description: A guide for creating custom MLflow models
 slug: custom-pyfunc
 authors: [daniel-liden]
 tags: [pyfunc, models]
-thumbnail: img/blog/custom-pyfunc.png
+thumbnail: /img/blog/custom-pyfunc.png
 ---
 
 If you're looking to learn about all of the flexibility and customization that is possible within

--- a/website/blog/2024-01-25-databricks-ce/index.md
+++ b/website/blog/2024-01-25-databricks-ce/index.md
@@ -2,7 +2,7 @@
 title: Streamline your MLflow Projects with Free Hosted MLflow
 description: A guide to using Databricks Community Edition with integrated managed MLflow
 slug: databricks-ce
-thumbnail: img/blog/databricks-ce.png
+thumbnail: /img/blog/databricks-ce.png
 authors: [abe-omorogbe]
 tags: [managed mlflow, getting started]
 ---

--- a/website/blog/2024-01-26-mlflow-year-in-review/index.md
+++ b/website/blog/2024-01-26-mlflow-year-in-review/index.md
@@ -4,7 +4,7 @@ description: MLflow year-end recap
 slug: mlflow-year-in-review
 authors: [carly-akerly]
 tags: [MLflow, "2023", Linux Foundation]
-thumbnail: img/blog/2023-year-in-review.png
+thumbnail: /img/blog/2023-year-in-review.png
 ---
 
 With more than **16 million** monthly downloads, MLflow has established itself as a leading open-source MLOps platform worldwide.

--- a/website/blog/2024-03-05-deep-learning-part-1/index.md
+++ b/website/blog/2024-03-05-deep-learning-part-1/index.md
@@ -4,7 +4,7 @@ description: Highlighting the recent improvements in MLflow for Deep Learning wo
 slug: deep-learning-part-1
 authors: [abe-omorogbe, hubert-zub, yun-park, chen-qian, jesse-chan]
 tags: [Deep Learning]
-thumbnail: img/blog/dl-chart-grouping.gif
+thumbnail: /img/blog/dl-chart-grouping.gif
 ---
 
 In the quickly evolving world of artificial intelligence, where generative AI has taken center stage, the landscape of machine learning is

--- a/website/blog/2024-04-17-release-candidates.md
+++ b/website/blog/2024-04-17-release-candidates.md
@@ -3,7 +3,7 @@ title: MLflow Release Candidates
 tags: [mlflow]
 slug: release-candidates
 authors: [mlflow-maintainers]
-thumbnail: img/blog/release-candidates.png
+thumbnail: /img/blog/release-candidates.png
 ---
 
 # Announcing MLflow Release Candidates

--- a/website/blog/2024-04-26-deep-learning-part-2/index.md
+++ b/website/blog/2024-04-26-deep-learning-part-2/index.md
@@ -4,7 +4,7 @@ description: Using MLflow's Deep Learning tracking features for fine tuning an L
 slug: deep-learning-part-2
 authors: [puneet-jain, avinash-sooriyarachchi, abe-omorogbe, ben]
 tags: [Deep Learning]
-thumbnail: img/blog/dl-blog-2.png
+thumbnail: /img/blog/dl-blog-2.png
 ---
 
 In the realm of deep learning, finetuning of pre-trained Large Language Models (LLMs) on private datasets is an excellent customization

--- a/website/blog/2024-06-10-mlflow-tracing/index.md
+++ b/website/blog/2024-06-10-mlflow-tracing/index.md
@@ -3,7 +3,7 @@ title: Introducing MLflow Tracing
 tags: [tracing, genai, mlops]
 slug: mlflow-tracing
 authors: [mlflow-maintainers]
-thumbnail: img/blog/trace-intro.gif
+thumbnail: /img/blog/trace-intro.gif
 ---
 
 We're excited to announce the release of a powerful new feature in MLflow: [MLflow Tracing](https://mlflow.org/docs/latest/llms/tracing/index.html).

--- a/website/blog/2024-07-26-pyfunc-in-practice/index.md
+++ b/website/blog/2024-07-26-pyfunc-in-practice/index.md
@@ -4,7 +4,7 @@ description: Creative Applications of MLflow Pyfunc in Machine Learning Projects
 tags: [pyfunc, mlflow, ensemble-models]
 slug: pyfunc-in-practice
 authors: [hugo-carvalho, joana-ferreira, rahul-pandey, filipe-miranda]
-thumbnail: img/blog/pyfunc-in-practice.png
+thumbnail: /img/blog/pyfunc-in-practice.png
 ---
 
 If you're looking to fully leverage the capabilities of `mlflow.pyfunc` and understand how it can be utilized in a Machine Learning project, this blog post will guide you through the process. MLflow PyFunc offers creative freedom and flexibility, allowing the development of complex systems encapsulated as models in MLflow that follow the same lifecycle as traditional ones. This blog will showcase how to create multi-model setups, seamlessly connect to databases, and implement your own custom fit method in your MLflow PyFunc model.

--- a/website/blog/2024-08-06-langgraph-pyfunc/index.md
+++ b/website/blog/2024-08-06-langgraph-pyfunc/index.md
@@ -3,7 +3,7 @@ title: LangGraph with Custom PyFunc
 tags: [genai, mlops]
 slug: mlflow
 authors: [michael-berk, mlflow-maintainers]
-thumbnail: img/blog/release-candidates.png
+thumbnail: /img/blog/release-candidates.png
 ---
 
 In this blog, we'll guide you through creating a LangGraph chatbot within an MLflow custom PyFunc. By combining MLflow with LangGraph's ability to create and manage cyclical graphs, you can create powerful stateful, multi-actor applications in a scalable fashion.

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,7 @@
     "fmt": "prettier --write .",
     "fmt-notes": "ts-node scripts/release-note-format.js",
     "compile": "ts-node scripts/compile.ts && prettier --write src/posts.ts",
+    "check-thumbnails": "ts-node scripts/check-thumbnails.ts",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",

--- a/website/scripts/check-thumbnails.ts
+++ b/website/scripts/check-thumbnails.ts
@@ -1,0 +1,47 @@
+import fs from "fs";
+import path from "path";
+
+function getMarkdownFiles(dir: string, fileList: string[] = []): string[] {
+  const files = fs.readdirSync(dir);
+
+  files.forEach((file) => {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+
+    if (stat.isDirectory()) {
+      getMarkdownFiles(filePath, fileList);
+    } else if (filePath.endsWith(".md")) {
+      fileList.push(filePath);
+    }
+  });
+
+  return fileList;
+}
+
+function checkForThumbnailString(filePaths: string[]): string[] {
+  const matchingFiles: string[] = [];
+
+  filePaths.forEach((filePath) => {
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+
+    // check for the absence of a leading slash in the thumbnail path
+    // this will cause the image to be broken on /blog/tags/... pages
+    if (fileContent.includes("thumbnail: img")) {
+      matchingFiles.push(filePath);
+    }
+  });
+
+  return matchingFiles;
+}
+
+const markdownFiles = getMarkdownFiles("./blog");
+const filesWithoutTrailingSlash = checkForThumbnailString(markdownFiles);
+
+if (filesWithoutTrailingSlash.length > 0) {
+  console.log("Found files with broken thumbnail paths:");
+  console.log(filesWithoutTrailingSlash);
+  console.log(
+    "Please add a leading slash to the thumbnail path, otherwise the image will be broken on /blog/tags/... pages",
+  );
+  process.exit(1);
+}

--- a/website/src/components/BlogItem/index.tsx
+++ b/website/src/components/BlogItem/index.tsx
@@ -3,6 +3,10 @@ import { Blog as BlogType } from "../../posts";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 
+function formatTag(tag: string): string {
+  return tag.replace(/\s+/g, "-").toLowerCase();
+}
+
 function Blog({ blog }: { blog: BlogType }): JSX.Element {
   const { title, path, tags, authors, date, thumbnail } = blog;
   const author = authors[0];
@@ -33,7 +37,9 @@ function Blog({ blog }: { blog: BlogType }): JSX.Element {
                       "button button--sm button--outline button--primary",
                       styles.tag,
                     )}
-                    href={`/blog/tags/${tag}`}
+                    key={tag}
+                    href={`/blog/tags/${formatTag(tag)}`}
+                    onClick={(e) => e.stopPropagation()}
                   >
                     {tag}
                   </a>

--- a/website/src/posts.ts
+++ b/website/src/posts.ts
@@ -45,7 +45,7 @@ export const BLOGS: Blog[] = [
       },
     ],
     date: "2024-08-06",
-    thumbnail: "img/blog/release-candidates.png",
+    thumbnail: "/img/blog/release-candidates.png",
   },
   {
     title: "PyFunc in Practice",
@@ -78,7 +78,7 @@ export const BLOGS: Blog[] = [
       },
     ],
     date: "2024-07-26",
-    thumbnail: "img/blog/pyfunc-in-practice.png",
+    thumbnail: "/img/blog/pyfunc-in-practice.png",
   },
   {
     title: "Introducing MLflow Tracing",
@@ -93,7 +93,7 @@ export const BLOGS: Blog[] = [
       },
     ],
     date: "2024-06-10",
-    thumbnail: "img/blog/trace-intro.gif",
+    thumbnail: "/img/blog/trace-intro.gif",
   },
   {
     title: "Deep Learning with MLflow (Part 2)",
@@ -126,7 +126,7 @@ export const BLOGS: Blog[] = [
       },
     ],
     date: "2024-04-26",
-    thumbnail: "img/blog/dl-blog-2.png",
+    thumbnail: "/img/blog/dl-blog-2.png",
   },
   {
     title: "MLflow Release Candidates",
@@ -141,7 +141,7 @@ export const BLOGS: Blog[] = [
       },
     ],
     date: "2024-04-17",
-    thumbnail: "img/blog/release-candidates.png",
+    thumbnail: "/img/blog/release-candidates.png",
   },
   {
     title:
@@ -179,7 +179,7 @@ export const BLOGS: Blog[] = [
       },
     ],
     date: "2024-03-05",
-    thumbnail: "img/blog/dl-chart-grouping.gif",
+    thumbnail: "/img/blog/dl-chart-grouping.gif",
   },
   {
     title: "2023 Year in Review",
@@ -194,7 +194,7 @@ export const BLOGS: Blog[] = [
       },
     ],
     date: "2024-01-26",
-    thumbnail: "img/blog/2023-year-in-review.png",
+    thumbnail: "/img/blog/2023-year-in-review.png",
   },
   {
     title: "Streamline your MLflow Projects with Free Hosted MLflow",
@@ -209,7 +209,7 @@ export const BLOGS: Blog[] = [
       },
     ],
     date: "2024-01-25",
-    thumbnail: "img/blog/databricks-ce.png",
+    thumbnail: "/img/blog/databricks-ce.png",
   },
   {
     title: "Custom MLflow Models with mlflow.pyfunc",
@@ -224,7 +224,7 @@ export const BLOGS: Blog[] = [
       },
     ],
     date: "2024-01-23",
-    thumbnail: "img/blog/custom-pyfunc.png",
+    thumbnail: "/img/blog/custom-pyfunc.png",
   },
   {
     title: "MLflow AI Gateway renamed to MLflow Deployments for LLMs",
@@ -239,7 +239,7 @@ export const BLOGS: Blog[] = [
       },
     ],
     date: "2023-12-01",
-    thumbnail: "img/blog/ai-gateway.png",
+    thumbnail: "/img/blog/ai-gateway.png",
   },
   {
     title:
@@ -255,7 +255,7 @@ export const BLOGS: Blog[] = [
       },
     ],
     date: "2023-11-30",
-    thumbnail: "img/blog/mlflow-autolog.png",
+    thumbnail: "/img/blog/mlflow-autolog.png",
   },
   {
     title: "MLflow Docs Overhaul",
@@ -270,7 +270,7 @@ export const BLOGS: Blog[] = [
       },
     ],
     date: "2023-10-31",
-    thumbnail: "img/blog/docs-overhaul.png",
+    thumbnail: "/img/blog/docs-overhaul.png",
   },
 ];
 

--- a/website/src/theme/BlogLayout/index.js
+++ b/website/src/theme/BlogLayout/index.js
@@ -4,7 +4,6 @@ import Layout from "@theme/Layout";
 import BlogSidebar from "@theme/BlogSidebar";
 export default function BlogLayout(props) {
   const { sidebar, toc, children, ...layoutProps } = props;
-  console.log(sidebar.items);
   const isBlog = sidebar.items.some(({ permalink }) =>
     permalink.startsWith("/blog/"),
   );

--- a/website/src/theme/BlogPostItems/index.js
+++ b/website/src/theme/BlogPostItems/index.js
@@ -14,8 +14,11 @@ export default function BlogPostItems({
   if (isBlog) {
     return (
       <>
-        {BLOGS.map((blog) => (
-          <BlogItem key={blog.id} blog={blog} />
+        {items.map(({ content }) => (
+          <BlogItem
+            key={content.metadata.permalink}
+            blog={content.metadata.frontMatter}
+          />
         ))}
       </>
     );


### PR DESCRIPTION
This PR fixes broken links in `/blog/tags/...`. For example: https://mlflow.org/blog/tags/genai

Images need to have a leading slash, otherwise it will look for the image in `/blog/tags/img/...`, which doesn't exist. I also added a workflow to the CI job to enforce this.

Also, I fixed a couple more issues related to tags:
1. Users can't actually click on the tags right now
2. The tags page displays all blogs rather than just the tagged ones
3. The tag links need to be lowercased and have spaces replaced with `-` (e.g. `Deep Learning -> /blog/tags/deep-learning`, otherwise it leads to a broken page