### PR TITLE
Add gtag for Google ads

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -49,6 +49,10 @@ const config: Config = {
         googleTagManager: {
           containerId: process.env.GTM_ID || "GTM-TEST",
         },
+        gtag: {
+          trackingID: process.env.GTAG_ID || "GTAG-TEST",
+          anonymizeIP: true,
+        },
       } satisfies Preset.Options,
     ],
   ],

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -50,7 +50,7 @@ const config: Config = {
           containerId: process.env.GTM_ID || "GTM-TEST",
         },
         gtag: {
-          trackingID: process.env.GTAG_ID || "GTAG-TEST",
+          trackingID: "AW-16857946923",
           anonymizeIP: true,
         },
       } satisfies Preset.Options,


### PR DESCRIPTION
Add an env var lookup to set the `gtag` tracking ID for Google Analytics.