### PR TITLE
code block formatting fix in Tracing Intro blog

### DIFF
--- a/website/blog/2025-03-06-tracing-introduction/index.mdx
+++ b/website/blog/2025-03-06-tracing-introduction/index.mdx
@@ -138,8 +138,9 @@ Here are a few examples. See [here](https://mlflow.org/docs/latest/tracing#autom
   <TabItem value="Anthropic" label="Anthropic" default>
   
   Enable automatic tracing for Anthropic model calls with `mlflow.anthropic.autolog()`.
-  
-  ```python
+
+{/* prettier-ignore-start */}
+```python
 import anthropic
 import mlflow
 
@@ -148,23 +149,23 @@ mlflow.anthropic.autolog()
 client = anthropic.Anthropic()
 
 message = client.messages.create(
-model="claude-3-7-sonnet-20250219",
-max_tokens=1000,
-temperature=1,
-messages=[
-{
-"role": "user",
-"content": "What is an MLflow tracking server?"
-}
-]
+    model="claude-3-7-sonnet-20250219",
+    max_tokens=1000,
+    temperature=1,
+    messages=[
+        {
+            "role": "user",
+            "content": "What is an MLflow tracking server?"
+        }
+    ]
 )
 
 ````
+{/* prettier-ignore-end */}
 
 This returns the following in the MLflow UI:
 
 ![Anthropic tracing](/img/blog/tracing-intro/04_anthropic.png)
-
 
   </TabItem>
   <TabItem value="langchain" label="LangChain">
@@ -200,7 +201,7 @@ chain.invoke(
         "question": "How do MLflow tracking servers help with experiment management?",
     }
 )
-````
+```
 
 This example LangChain chain includes multiple components:
 


### PR DESCRIPTION
adds prettier ignore blocks around section yarn fmt was formatting incorrectly