### PR TITLE
Make header product submenu responsive

### DIFF
--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -31,6 +31,10 @@ export const Header = () => {
     setIsProductItemHovered(false);
   };
 
+  const toggleProductSubmenuHovered = () => {
+    setIsProductItemHovered(!isProductItemHovered);
+  };
+
   const handleProductItemClick = () => {
     setIsProductSubmenuOpen(!isProductSubmenuOpen);
   };
@@ -122,6 +126,7 @@ export const Header = () => {
             <li
               className="w-full md:w-auto hidden md:block"
               onMouseEnter={handleProductItemHover}
+              onClick={toggleProductSubmenuHovered}
             >
               <HeaderMenuItem label="Product" hasDropdown />
             </li>

--- a/website/src/components/HeaderProductsSubmenu/HeaderProductsSubmenu.tsx
+++ b/website/src/components/HeaderProductsSubmenu/HeaderProductsSubmenu.tsx
@@ -1,3 +1,4 @@
+import Link from "@docusaurus/Link";
 import { HeaderMenuItem } from "../HeaderMenuItem/HeaderMenuItem";
 
 export const HeaderProductsSubmenu = () => {
@@ -5,8 +6,12 @@ export const HeaderProductsSubmenu = () => {
     <div className="flex flex-col md:flex-row md:max-w-4xl mx-auto gap-6 md:gap-8 lg:gap-10 px-4 lg:pl-0 products-submenu">
       <div className="flex flex-col gap-1 md:gap-4">
         <div className="flex flex-col gap-1 md:gap-4 md:border-b border-[#F7F8F8]/8 pb-4">
-          <h3>Gen AI</h3>
-          <p className="text-[#F7F8F8]/60 m-0">Ship high-quality GenAI, fast</p>
+          <Link to="/genai">
+            <h3 className="text-white">Gen AI</h3>
+            <p className="text-[#F7F8F8]/60 m-0">
+              Ship high-quality GenAI, fast
+            </p>
+          </Link>
         </div>
         <div className="flex flex-col gap-3">
           <span className="text-[#F7F8F8]/60 text-sm">Features</span>
@@ -35,8 +40,10 @@ export const HeaderProductsSubmenu = () => {
       </div>
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-1 md:gap-4 md:border-b border-[#F7F8F8]/8 pb-4">
-          <h3>Model training</h3>
-          <p className="text-[#F7F8F8]/60">Mastering the ML lifecycle</p>
+          <Link to="/classical-ml">
+            <h3 className="text-white">Model training</h3>
+            <p className="text-[#F7F8F8]/60">Mastering the ML lifecycle</p>
+          </Link>
         </div>
         <div className="flex flex-col gap-3">
           <span className="text-[#F7F8F8]/60 text-sm">Features</span>
@@ -45,7 +52,7 @@ export const HeaderProductsSubmenu = () => {
               <HeaderMenuItem href="/classical-ml/tracking" label="Tracking" />
               <HeaderMenuItem
                 href="/classical-ml/hyperparam-tuning"
-                label="Hyperparam tuning"
+                label="Hyperparameter tuning"
               />
               <HeaderMenuItem href="/classical-ml/models" label="Models" />
             </div>

--- a/website/src/components/HeaderProductsSubmenu/HeaderProductsSubmenu.tsx
+++ b/website/src/components/HeaderProductsSubmenu/HeaderProductsSubmenu.tsx
@@ -2,16 +2,16 @@ import { HeaderMenuItem } from "../HeaderMenuItem/HeaderMenuItem";
 
 export const HeaderProductsSubmenu = () => {
   return (
-    <div className="flex flex-col md:flex-row md:max-w-4xl mx-auto gap-6 md:gap-10 pl-4 md:pl-0 products-submenu">
+    <div className="flex flex-col md:flex-row md:max-w-4xl mx-auto gap-6 md:gap-8 lg:gap-10 px-4 lg:pl-0 products-submenu">
       <div className="flex flex-col gap-1 md:gap-4">
-        <div className="flex flex-col gap-2 md:border-b border-[#F7F8F8]/8 pb-4">
+        <div className="flex flex-col gap-1 md:gap-4 md:border-b border-[#F7F8F8]/8 pb-4">
           <h3>Gen AI</h3>
           <p className="text-[#F7F8F8]/60 m-0">Ship high-quality GenAI, fast</p>
         </div>
         <div className="flex flex-col gap-3">
           <span className="text-[#F7F8F8]/60 text-sm">Features</span>
-          <div className="flex flex-row">
-            <div className="min-w-50 flex flex-col gap-4 md:gap-1">
+          <div className="flex flex-row gap-8">
+            <div className="min-w-40 flex flex-col gap-4 md:gap-1">
               <HeaderMenuItem
                 href="/genai/quality-metrics"
                 label="Quality metrics"
@@ -22,7 +22,7 @@ export const HeaderProductsSubmenu = () => {
               />
               <HeaderMenuItem href="/genai/evaluations" label="Evaluations" />
             </div>
-            <div className="min-w-50 flex flex-col gap-4 md:gap-1">
+            <div className="min-w-40 flex flex-col gap-4 md:gap-1">
               <HeaderMenuItem
                 href="/genai/human-feedback"
                 label="Human feedback"
@@ -40,16 +40,16 @@ export const HeaderProductsSubmenu = () => {
         </div>
         <div className="flex flex-col gap-3">
           <span className="text-[#F7F8F8]/60 text-sm">Features</span>
-          <div className="flex flex-row">
-            <div className="min-w-50 flex flex-col gap-4 md:gap-1">
+          <div className="flex flex-row gap-8">
+            <div className="min-w-40 flex flex-col gap-4 md:gap-1">
               <HeaderMenuItem href="/classical-ml/tracking" label="Tracking" />
               <HeaderMenuItem
                 href="/classical-ml/hyperparam-tuning"
-                label="Hyperparameter tuning"
+                label="Hyperparam tuning"
               />
               <HeaderMenuItem href="/classical-ml/models" label="Models" />
             </div>
-            <div className="min-w-50 flex flex-col gap-4 md:gap-1">
+            <div className="min-w-40 flex flex-col gap-4 md:gap-1">
               <HeaderMenuItem
                 href="/classical-ml/unified-registry"
                 label="Unified registry"

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -21,7 +21,7 @@ export default function Home(): JSX.Element {
       >
         <div className="flex flex-col gap-16 w-full px-6 md:px-20 max-w-container">
           <div className="flex flex-col justify-center items-center gap-6 w-full">
-            <h1 className="text-center text-wrap">AI and ML made simple</h1>
+            <h1 className="text-center text-wrap">ML and GenAI made simple</h1>
             <p className="text-center text-wrap text-lg text-white">
               The AI developer platform to build AI applications and models with
               confidence

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -21,7 +21,7 @@ export default function Home(): JSX.Element {
       >
         <div className="flex flex-col gap-16 w-full px-6 md:px-20 max-w-container">
           <div className="flex flex-col justify-center items-center gap-6 w-full">
-            <h1 className="text-center text-wrap">ML and GenAI made simple</h1>
+            <h1 className="text-center text-wrap">AI and ML made simple</h1>
             <p className="text-center text-wrap text-lg text-white">
               The AI developer platform to build AI applications and models with
               confidence


### PR DESCRIPTION
This makes the product submenu fit the screen on tablet viewport, and allows toggling the submenu with click/press on desktop and tablet, which was inaccessible for tablet users before.