### PR TITLE
Fix header items readability on white backgrounds with drop-shadow

### DIFF
--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -50,7 +50,7 @@ export const Header = () => {
   }, []);
 
   return (
-    <nav className="fixed w-full z-20 top-0 start-0 bg-[#F7F8F8]/1 border-b border-[#F7F8F8]/8 backdrop-blur-[20px]">
+    <nav className="fixed w-full z-20 top-0 start-0 bg-[#F7F8F8]/1 border-b border-[#F7F8F8]/8 backdrop-blur-[20px] drop-shadow-[0px_1px_2px_rgba(0_0_0/75%),0px_1px_12px_rgba(0_0_0/75%)]">
       <div className="flex flex-wrap items-center justify-between mx-auto px-6 md:px-20 py-2 max-w-container">
         <Link
           href="/"


### PR DESCRIPTION
I opted to use a drop-shadow filter instead of text-shadow so it applies to the caret SVG as well. I overlaid two shadows, the one with smaller dispersion is for readability and the larger one for aesthetics.