### PR TITLE
Read accent colors from layout context

### DIFF
--- a/website/src/components/GetStartedWithMLflow/GetStartedWithMLflow.tsx
+++ b/website/src/components/GetStartedWithMLflow/GetStartedWithMLflow.tsx
@@ -5,12 +5,10 @@ import { GetStartedButton } from "../GetStartedButton/GetStartedButton";
 import { cn } from "../../utils";
 import { Heading } from "../Typography/Heading";
 import { Body } from "../Typography/Body";
+import { useLayoutVariant } from "../Layout/Layout";
 
-interface Props {
-  variant?: "red" | "blue";
-}
-
-export const GetStartedWithMLflow = ({ variant = "red" }: Props) => {
+export const GetStartedWithMLflow = () => {
+  const variant = useLayoutVariant();
   return (
     <div className="flex flex-col lg:flex-row w-full justify-between gap-6">
       <div className="flex flex-col gap-6 w-full lg:w-1/2 items-start">

--- a/website/src/components/LatestNews/LatestNews.tsx
+++ b/website/src/components/LatestNews/LatestNews.tsx
@@ -5,12 +5,10 @@ import { Grid, GridItem } from "../Grid/Grid";
 import { SectionLabel } from "../SectionLabel/SectionLabel";
 import { Button } from "../Button/Button";
 import { Heading } from "../Typography/Heading";
+import { useLayoutVariant } from "../Layout/Layout";
 
-interface Props {
-  variant: "red" | "green";
-}
-
-export const LatestNews = ({ variant }: Props) => {
+export const LatestNews = () => {
+  const variant = useLayoutVariant() === "blue" ? "green" : "red";
   const posts = BLOGS.slice(0, 3);
 
   const viewAllLinkNode = (

--- a/website/src/components/Layout/Layout.tsx
+++ b/website/src/components/Layout/Layout.tsx
@@ -1,7 +1,7 @@
 import { Header } from "../Header/Header";
 import { Footer } from "../Footer/Footer";
 import { cva, VariantProps } from "class-variance-authority";
-import { PropsWithChildren } from "react";
+import { createContext, PropsWithChildren, useContext } from "react";
 
 type Props = PropsWithChildren<VariantProps<typeof wrapper>>;
 
@@ -66,14 +66,26 @@ const wrapper = cva(
   },
 );
 
+const LayoutContext = createContext<"red" | "blue" | "colorful">("colorful");
+
+export function useLayoutVariant() {
+  const variant = useContext(LayoutContext);
+  if (variant === undefined) {
+    throw new Error("useLayoutVariant must be used within a Layout");
+  }
+  return variant;
+}
+
 export const Layout = ({ children, variant, direction }: Props) => {
   return (
-    <div className="flex flex-col min-h-screen w-full bg-[#0E1416]">
-      <Header />
-      <main className="flex flex-col">
-        <div className={wrapper({ variant, direction })}>{children}</div>
-      </main>
-      <Footer variant={variant} />
-    </div>
+    <LayoutContext.Provider value={variant}>
+      <div className="flex flex-col min-h-screen w-full bg-[#0E1416]">
+        <Header />
+        <main className="flex flex-col">
+          <div className={wrapper({ variant, direction })}>{children}</div>
+        </main>
+        <Footer variant={variant} />
+      </div>
+    </LayoutContext.Provider>
   );
 };

--- a/website/src/components/SocialWidget/SocialWidget.tsx
+++ b/website/src/components/SocialWidget/SocialWidget.tsx
@@ -8,10 +8,7 @@ import { SocialWidgetItem } from "../SocialWidgetItem/SocialWidgetItem";
 import { Grid, GridItem } from "../Grid/Grid";
 import { Heading } from "../Typography/Heading";
 import { Body } from "../Typography/Body";
-
-interface Props {
-  variant: "red" | "green";
-}
+import { useLayoutVariant } from "../Layout/Layout";
 
 const socials = [
   {
@@ -48,7 +45,8 @@ const socials = [
   },
 ];
 
-export const SocialWidget = ({ variant }: Props) => {
+export const SocialWidget = () => {
+  const variant = useLayoutVariant() === "blue" ? "green" : "red";
   return (
     <div className="flex flex-col w-full gap-16">
       <div className="flex flex-col w-full gap-6 items-center justify-center text-center">

--- a/website/src/pages/classical-ml/hyperparam-tuning.tsx
+++ b/website/src/pages/classical-ml/hyperparam-tuning.tsx
@@ -76,8 +76,8 @@ export default function HyperparamTuning() {
             <FakeImage />
           </GridItem>
         </Grid>
-        <GetStartedWithMLflow variant="blue" />
-        <SocialWidget variant="green" />
+        <GetStartedWithMLflow />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/classical-ml/index.tsx
+++ b/website/src/pages/classical-ml/index.tsx
@@ -154,9 +154,9 @@ export default function GenAi(): JSX.Element {
             </GridItem>
           </Grid>
         </div>
-        <GetStartedWithMLflow variant="blue" />
-        <LatestNews variant="green" />
-        <SocialWidget variant="green" />
+        <GetStartedWithMLflow />
+        <LatestNews />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/classical-ml/models.tsx
+++ b/website/src/pages/classical-ml/models.tsx
@@ -76,8 +76,8 @@ export default function Models() {
             <FakeImage />
           </GridItem>
         </Grid>
-        <GetStartedWithMLflow variant="blue" />
-        <SocialWidget variant="green" />
+        <GetStartedWithMLflow />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/classical-ml/serving.tsx
+++ b/website/src/pages/classical-ml/serving.tsx
@@ -72,8 +72,8 @@ export default function Serving() {
             <FakeImage />
           </GridItem>
         </Grid>
-        <GetStartedWithMLflow variant="blue" />
-        <SocialWidget variant="green" />
+        <GetStartedWithMLflow />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/classical-ml/tracking.tsx
+++ b/website/src/pages/classical-ml/tracking.tsx
@@ -73,8 +73,8 @@ export default function Tracking() {
             <FakeImage />
           </GridItem>
         </Grid>
-        <GetStartedWithMLflow variant="blue" />
-        <SocialWidget variant="green" />
+        <GetStartedWithMLflow />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/classical-ml/unified-registry.tsx
+++ b/website/src/pages/classical-ml/unified-registry.tsx
@@ -76,8 +76,8 @@ export default function UnifiedRegistry() {
             <FakeImage />
           </GridItem>
         </Grid>
-        <GetStartedWithMLflow variant="blue" />
-        <SocialWidget variant="green" />
+        <GetStartedWithMLflow />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/genai/ai-gateway.tsx
+++ b/website/src/pages/genai/ai-gateway.tsx
@@ -68,7 +68,7 @@ export default function AiGateway() {
           </GridItem>
         </Grid>
         <GetStartedWithMLflow />
-        <SocialWidget variant="red" />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/genai/evaluations.tsx
+++ b/website/src/pages/genai/evaluations.tsx
@@ -170,7 +170,7 @@ export default function Evaluations() {
           </Grid>
         </div>
         <GetStartedWithMLflow />
-        <SocialWidget variant="red" />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/genai/governance.tsx
+++ b/website/src/pages/genai/governance.tsx
@@ -105,7 +105,7 @@ export default function Governance() {
           </GridItem>
         </Grid>
         <GetStartedWithMLflow />
-        <SocialWidget variant="red" />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/genai/human-feedback.tsx
+++ b/website/src/pages/genai/human-feedback.tsx
@@ -96,7 +96,7 @@ export default function HumanFeedback() {
           </GridItem>
         </Grid>
         <GetStartedWithMLflow />
-        <SocialWidget variant="red" />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/genai/index.tsx
+++ b/website/src/pages/genai/index.tsx
@@ -337,8 +337,8 @@ export default function GenAi(): JSX.Element {
           </Grid>
         </div>
         <GetStartedWithMLflow />
-        <LatestNews variant="red" />
-        <SocialWidget variant="red" />
+        <LatestNews />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/genai/observability.tsx
+++ b/website/src/pages/genai/observability.tsx
@@ -246,7 +246,7 @@ export default function Observability() {
         </div>
 
         <GetStartedWithMLflow />
-        <SocialWidget variant="red" />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/genai/prompt-registry-versioning.tsx
+++ b/website/src/pages/genai/prompt-registry-versioning.tsx
@@ -48,7 +48,7 @@ export default function PromptRegistryVersioning() {
         </Grid>
 
         <GetStartedWithMLflow />
-        <SocialWidget variant="red" />
+        <SocialWidget />
       </div>
     </Layout>
   );

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -55,9 +55,9 @@ export default function Home(): JSX.Element {
           <LogosCarousel />
         </div>
         <GetStartedWithMLflow />
-        <LatestNews variant="red" />
+        <LatestNews />
         <GetStartedTagline />
-        <SocialWidget variant="red" />
+        <SocialWidget />
       </div>
     </Layout>
   );


### PR DESCRIPTION
This change adds layout context for colors; colorful, red and blue. With this, components that need accent colors can read the color from context and there's no need to pass color manually, avoiding potential inconsistencies and tedious work.