### PR TITLE
[5/x] add gradient background for product images 

### DIFF
--- a/website/src/components/Card/Card.tsx
+++ b/website/src/components/Card/Card.tsx
@@ -34,6 +34,27 @@ const imageWrapper = cva("w-full relative", {
   },
 });
 
+type ThemeColor = {
+  startColor: string;
+  endColor: string;
+} | null;
+
+function getThemeColor(pathname: string): ThemeColor {
+  if (pathname.startsWith("/genai")) {
+    return {
+      startColor: "#EB1700",
+      endColor: "#4A121A",
+    };
+  }
+  if (pathname.startsWith("/classical-ml")) {
+    return {
+      startColor: "#54c7ec",
+      endColor: "#0A2342",
+    };
+  }
+  return null;
+}
+
 export function Card({
   title,
   body,
@@ -41,9 +62,10 @@ export function Card({
   cta,
   image,
   padded = false,
-  rounded = true,
 }: Props) {
   const bodyParts = Array.isArray(body) ? body : [body];
+  const colors = getThemeColor(location.pathname);
+
   return (
     <>
       <div className={contentWrapper({ padded })}>
@@ -67,9 +89,31 @@ export function Card({
         )}
       </div>
       {image && (
-        <div className={imageWrapper({ rounded })}>
-          {image}
-          <div className="absolute inset-0 bg-black/5 pointer-events-none" />
+        <div
+          className="relative"
+          style={
+            colors
+              ? {
+                  paddingTop: "3%",
+                  paddingLeft: "3%",
+                  backgroundImage: `linear-gradient(to bottom, ${colors.startColor} 0%, ${colors.startColor} 50%, ${colors.endColor} 100%)`,
+                }
+              : undefined
+          }
+        >
+          {(() => {
+            const rounded = colors
+              ? "rounded-tl-3xl rounded-tr-3xl rounded-bl-3xl"
+              : "";
+            return (
+              <div className={`relative overflow-hidden ${rounded}`}>
+                {image}
+                <div
+                  className={`absolute inset-0 bg-black/5 pointer-events-none ${rounded}`}
+                />
+              </div>
+            );
+          })()}
         </div>
       )}
     </>

--- a/website/src/components/Card/Card.tsx
+++ b/website/src/components/Card/Card.tsx
@@ -1,6 +1,6 @@
 import Link from "@docusaurus/Link";
 import { Body, Button, Heading } from "..";
-import { ComponentProps, ReactNode } from "react";
+import { ComponentProps, ReactNode, useEffect, useState } from "react";
 import { cva, VariantProps } from "class-variance-authority";
 
 type Props = {
@@ -64,7 +64,13 @@ export function Card({
   padded = false,
 }: Props) {
   const bodyParts = Array.isArray(body) ? body : [body];
-  const colors = getThemeColor(location.pathname);
+  const [colors, setColors] = useState(null);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setColors(getThemeColor(location.pathname));
+    }
+  }, []);
 
   return (
     <>

--- a/website/src/components/ExpandableGrid/ExpandableGrid.tsx
+++ b/website/src/components/ExpandableGrid/ExpandableGrid.tsx
@@ -17,6 +17,7 @@ const ExpandableGrid = ({ items, defaultVisibleCount, renderItem }) => {
           </div>
         ))}
       </div>
+
       {items.length > defaultVisibleCount && (
         <div className={styles.buttonContainer}>
           <button

--- a/website/src/components/ExpandableGrid/styles.module.css
+++ b/website/src/components/ExpandableGrid/styles.module.css
@@ -23,12 +23,13 @@
 }
 
 .buttonContainer {
-  margin-top: 3rem;
+  margin-top: -1rem; /* bring button closer to the faded grid */
   text-align: center;
+  position: relative;
+  z-index: 1; /* ensures it shows even if fade uses z-index */
 }
 
 .toggleButton {
-  padding: 8px 16px;
   font-size: 16px;
   cursor: pointer;
   border: none;

--- a/website/src/components/GetStartedButton/GetStartedButton.tsx
+++ b/website/src/components/GetStartedButton/GetStartedButton.tsx
@@ -1,6 +1,6 @@
 import Link from "@docusaurus/Link";
 import { Button } from "../Button/Button";
-import { MLFLOW_SIGNUP_URL } from "@site/src/constants";
+import { MLFLOW_DOCS_URL } from "@site/src/constants";
 
 interface Props {
   variant?: "blue" | "primary" | "dark";
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export const GetStartedButton = ({
-  link = MLFLOW_SIGNUP_URL,
+  link = MLFLOW_DOCS_URL,
   size = "medium",
   width = "default",
   variant = "primary",


### PR DESCRIPTION
as subj

also moved the "see all" button to be closer to libraries

Test Plan:
<img width="1478" alt="image" src="https://github.com/user-attachments/assets/cc871252-9086-4495-b827-f0a68a0b4eab" />
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/fbc900b8-8b1b-4802-893e-ebf2a3b5000e" />

<img width="1356" alt="image" src="https://github.com/user-attachments/assets/59f57e27-a112-4c32-a93f-12e296838b07" />
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/cadd6927-dd2d-4b37-9e98-09bfd25fe8a8" />
