### PR TITLE
[10/x] Add background blur and overlay of black to header

### DIFF
--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -153,7 +153,7 @@ export const Header = ({ layoutType }: Props) => {
 
       <div
         className={cn(
-          "flex-col w-full py-6",
+          "flex-col w-full py-6 backdrop-blur bg-black/10",
           isProductItemHovered ? "flex" : "hidden",
         )}
         onMouseLeave={handleProductSubmenuLeave}


### PR DESCRIPTION
add 10% of black blur to the header dropdown view so the text is clearer when it overlays with white images

Test plan

before
<img width="1388" alt="image" src="https://github.com/user-attachments/assets/ad6224d2-366c-42f5-9027-6ed9de9ef7df" />


after
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/4193150c-9829-45bc-b982-bd8db24c7417" />
