### PR TITLE
Increase layout top padding so blog and release pages aren't occluded

### DIFF
--- a/website/src/components/Layout/AboveTheFold.tsx
+++ b/website/src/components/Layout/AboveTheFold.tsx
@@ -19,7 +19,7 @@ export function AboveTheFold({
 }: Props) {
   const bodyParts = Array.isArray(body) ? body : [body];
   return (
-    <div className="flex flex-col min-h-screen gap-6">
+    <div className="flex flex-col min-h-[calc(100dvh-var(--spacing)*40)] gap-6">
       <div className="flex flex-col justify-center items-center flex-1 gap-6 w-full max-w-5xl mx-auto md:px-4">
         {sectionLabel && <SectionLabel label={sectionLabel} />}
         <div className="max-w-4xl mx-auto">

--- a/website/src/components/Layout/Layout.tsx
+++ b/website/src/components/Layout/Layout.tsx
@@ -7,7 +7,7 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 type Props = PropsWithChildren;
 
-const wrapper = cva("flex flex-col gap-20 bg-no-repeat w-full py-10", {
+const wrapper = cva("flex flex-col gap-20 bg-no-repeat w-full py-20", {
   variants: {
     variant: {
       red: "",


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="935" alt="Screenshot 2025-06-10 at 09 37 27" src="https://github.com/user-attachments/assets/ffc41a1f-0d36-4705-acb1-cfb6c2d7623b" /> | <img width="937" alt="Screenshot 2025-06-10 at 09 37 47" src="https://github.com/user-attachments/assets/23baa790-1df4-4714-85b6-5fd4e22b0c9b" /> |