### PR TITLE
Replace `v3.1.0` with `v3.0.0`

### DIFF
--- a/website/releases/2025-06-11-3-release.md
+++ b/website/releases/2025-06-11-3-release.md
@@ -82,4 +82,4 @@ Explore the new MLflow 3 documentation and try out the enhanced GenAI capabiliti
 
 ## Full Changelog
 
-For the complete list of all changes, bug fixes, and improvements in MLflow 3, visit the [full changelog on GitHub](https://github.com/mlflow/mlflow/releases/tag/v3.0.0).
+For the complete list of all changes, bug fixes, and improvements in MLflow 3, visit the [full changelog on GitHub](https://github.com/mlflow/mlflow/releases/tag/v3.1.0).


### PR DESCRIPTION
The mlflow 3 release post includes both 3.0 and 3.1 changes. `v3.1.0` should be used.