### PR TITLE
Display texts in info box in black

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -154,3 +154,7 @@ small {
 .noScroll {
   overflow-y: hidden;
 }
+
+.alert--info p {
+  color: var(--color-brand-black) !important;
+}


### PR DESCRIPTION
before
<img width="740" alt="image" src="https://github.com/user-attachments/assets/cab23a2e-3875-4de3-a365-3cec56a011ad" />
after
<img width="644" alt="image" src="https://github.com/user-attachments/assets/29809b64-9497-46e7-9466-7574e64dd58f" />

