### PR TITLE
Don't allow hyphens for heading balancing

### DIFF
--- a/website/src/components/Typography/Heading.tsx
+++ b/website/src/components/Typography/Heading.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import type { PropsWithChildren } from "react";
 
-const styles = cva("hyphens-auto break-word", {
+const styles = cva("wrap-anywhere auto-phrase", {
   variants: {
     level: {
       1: "text-balance font-light text-[40px] xxs:text-[52px] xs:text-[64px] leading-[100%] tracking-[-3%] text-center",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -31,9 +31,7 @@
   --breakpoint-xs: 32rem;
 }
 
-@utility break-word {
-  word-break: break-word;
-
+@utility auto-phrase {
   /* Improve the word break for Chrome users */
   word-break: auto-phrase;
 }


### PR DESCRIPTION
 wrap as last resort,- Switch from deprecated `word-break: break-word` to `overflow-wrap`
- Keep Chrome-specific, experimental `word-break: auto-phrase` as
  fallback
- Responsive font sizes for headings avoid a lot of wrapping for long
  words in headings already
- Wrap as a last resort to avoid horizontal scroll