### PR TITLE
Update the get started button link on product details pages

### DIFF
--- a/website/src/pages/classical-ml/experiment-tracking.tsx
+++ b/website/src/pages/classical-ml/experiment-tracking.tsx
@@ -1,4 +1,3 @@
-import { MLFLOW_DOCS_URL } from "@site/src/constants";
 import {
   Layout,
   AboveTheFold,
@@ -21,7 +20,7 @@ export default function Tracking() {
         sectionLabel="Experiment tracking"
         title="Comprehensive experiment tracking"
         body=" Track, compare, and reproduce your machine learning experiments with MLflow's powerful tracking capabilities."
-        hasGetStartedButton={MLFLOW_DOCS_URL}
+        hasGetStartedButton="#get-started"
       >
         <HeroImage src={CardHero} alt="" />
       </AboveTheFold>

--- a/website/src/pages/classical-ml/model-evaluation.tsx
+++ b/website/src/pages/classical-ml/model-evaluation.tsx
@@ -1,4 +1,3 @@
-import { MLFLOW_DOCS_URL } from "@site/src/constants";
 import {
   Layout,
   AboveTheFold,
@@ -17,7 +16,7 @@ export default function ModelEvaluation() {
         sectionLabel="Model evaluation"
         title="Evaluate models with confidence"
         body="Automated evaluation tools for foundational ML techniques like classification and regression."
-        hasGetStartedButton={MLFLOW_DOCS_URL}
+        hasGetStartedButton="#get-started"
       >
         <HeroImage src={CardHero} alt="" />
       </AboveTheFold>

--- a/website/src/pages/classical-ml/model-registry.tsx
+++ b/website/src/pages/classical-ml/model-registry.tsx
@@ -1,4 +1,3 @@
-import { MLFLOW_DOCS_URL } from "@site/src/constants";
 import {
   Layout,
   AboveTheFold,
@@ -17,7 +16,7 @@ export default function ModelRegistryAndDeployment() {
         sectionLabel="Model registry & deployment"
         title="Deploy and manage models in production"
         body="Streamline your ML workflows with MLflow's comprehensive model registry for version control, approvals, and deployment management."
-        hasGetStartedButton={MLFLOW_DOCS_URL}
+        hasGetStartedButton="#get-started"
       >
         <HeroImage src={CardHero} alt="" />
       </AboveTheFold>

--- a/website/src/pages/classical-ml/models.tsx
+++ b/website/src/pages/classical-ml/models.tsx
@@ -1,4 +1,3 @@
-import { MLFLOW_DOCS_URL } from "@site/src/constants";
 import {
   Layout,
   AboveTheFold,
@@ -17,7 +16,7 @@ export default function Models() {
         sectionLabel="MLflow Models"
         title="Unified model packaging"
         body="A unified format to package, share, and deploy models across frameworks."
-        hasGetStartedButton={MLFLOW_DOCS_URL}
+        hasGetStartedButton="#get-started"
       >
         <HeroImage src={CardHero} alt="" />
       </AboveTheFold>

--- a/website/src/pages/genai/ai-gateway.tsx
+++ b/website/src/pages/genai/ai-gateway.tsx
@@ -1,4 +1,3 @@
-import { MLFLOW_DOCS_URL } from "@site/src/constants";
 import {
   Layout,
   AboveTheFold,
@@ -17,7 +16,7 @@ export default function AiGateway() {
         sectionLabel="AI gateway"
         title="Unified access to all AI models"
         body="Standardize how you interact with different LLM providers using one central interface."
-        hasGetStartedButton={MLFLOW_DOCS_URL}
+        hasGetStartedButton="#get-started"
       >
         <HeroImage src={CardHero} alt="" />
       </AboveTheFold>

--- a/website/src/pages/genai/app-versioning.tsx
+++ b/website/src/pages/genai/app-versioning.tsx
@@ -1,4 +1,3 @@
-import { MLFLOW_DOCS_URL } from "@site/src/constants";
 import {
   Layout,
   AboveTheFold,
@@ -18,7 +17,7 @@ export default function AppVersioning() {
         sectionLabel="App versioning"
         title="Manage app versions with ease"
         body="Track and compare different versions of GenAI applications to ensure quality and maintainability."
-        hasGetStartedButton={MLFLOW_DOCS_URL}
+        hasGetStartedButton="#get-started"
       >
         <HeroImage src={CardHero} alt="" />
       </AboveTheFold>

--- a/website/src/pages/genai/evaluations.tsx
+++ b/website/src/pages/genai/evaluations.tsx
@@ -1,4 +1,3 @@
-import { MLFLOW_DOCS_URL } from "@site/src/constants";
 import {
   Layout,
   AboveTheFold,
@@ -22,7 +21,7 @@ export default function Evaluations() {
         sectionLabel="Evaluations"
         title="Evaluation to measure and improve quality"
         body="Confidently evaluate quality in development and production to identify issues and iteratively test improvements."
-        hasGetStartedButton={MLFLOW_DOCS_URL}
+        hasGetStartedButton="#get-started"
       >
         <HeroImage src={CardHero} alt="" />
       </AboveTheFold>

--- a/website/src/pages/genai/observability.tsx
+++ b/website/src/pages/genai/observability.tsx
@@ -1,4 +1,3 @@
-import { MLFLOW_DOCS_URL } from "@site/src/constants";
 import {
   Layout,
   AboveTheFold,
@@ -24,7 +23,7 @@ export default function Observability() {
         sectionLabel="Observability"
         title="Observability for AI apps"
         body="Gain visibility into your app's logic to debug issues, improve quality and attach metadata to help you understand user behavior."
-        hasGetStartedButton={MLFLOW_DOCS_URL}
+        hasGetStartedButton="#get-started"
       >
         <HeroImage src={CardHero} alt="" />
       </AboveTheFold>

--- a/website/src/pages/genai/prompt-registry.tsx
+++ b/website/src/pages/genai/prompt-registry.tsx
@@ -1,4 +1,3 @@
-import { MLFLOW_DOCS_URL } from "@site/src/constants";
 import {
   Layout,
   AboveTheFold,
@@ -19,7 +18,7 @@ export default function PromptRegistryVersioning() {
         sectionLabel="Prompt registry"
         title="The single source of truth for your prompts"
         body="Create, store, and version prompts easily in the Prompt Registry."
-        hasGetStartedButton={MLFLOW_DOCS_URL}
+        hasGetStartedButton="#get-started"
       >
         <HeroImage src={CardHero} alt="" />
       </AboveTheFold>


### PR DESCRIPTION
a followup fix of https://github.com/mlflow/mlflow-website/pull/309

test plan:
yarn start and manually tested the buttons on all pages