### PR TITLE
Fix build docs failing with python 3.9

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
The [Deploy to GitHub pages](https://github.com/mlflow/mlflow-website/actions/runs/16259937087/job/45907219865) job was failing with the following message:

```
ERROR: Package 'mlflow' requires a different Python: 3.9.23 not in '>=3.10'
Error: Process completed with exit code 1.
```

So I upgraded python in `setup-python` step. Not sure if this alone will help, since the last 3 invocations of the job failed, but it's a step in the right direction.