### PR TITLE
Bump node version in deploy CI job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.10"
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
       - name: Build docs
         # Only build docs for main branch, otherwise
         # the build will take a long time.


### PR DESCRIPTION
Now it's [failing](https://github.com/mlflow/mlflow-website/actions/runs/16264203427/job/45916109967) with nodejs version error.

Followup to #333 