### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/website/blog/2024-08-29-autogen-pyfunc/index.md
+++ b/website/blog/2024-08-29-autogen-pyfunc/index.md
@@ -21,12 +21,12 @@ AutoGen is an open-source programming framework designed for building agent-base
 
 ## Setup
 
-First, let's install the required dependencies. Note that pyautogen requires `python>=3.9`.
+First, let's install the required dependencies. Note that ag2 requires `python>=3.9`.
 
 ### Environment Setup
 
 ```shell
-%pip install pyautogen mlflow -U -q
+%pip install ag2 mlflow -U -q
 ```
 
 We must also get API credentials to use an LLM. For this tutorial, we'll be using OpenAI. Note that a great way to securely pass tokens to your interactive python environment is via the [getpass](https://docs.python.org/3/library/getpass.html) package.


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
