### PR TITLE
Fix eval doc links in UI blog

### DIFF
--- a/website/blog/2025-08-11-mlflow-assessment-ui/index.mdx
+++ b/website/blog/2025-08-11-mlflow-assessment-ui/index.mdx
@@ -51,8 +51,8 @@ To start leveraging these new capabilities:
 2. **Open the trace viewer** by clicking on any trace in the trace detail view
 3. **Create your first assessment** using the assessments panel, no code required!
 
-For more in-depth tutorials on running evaluations with LLM judges, keep an eye out for upcoming documentation updates!
+For more in-depth tutorials on running evaluations with LLM judges and custom scorers, check out the [quickstart guide](https://mlflow.org/docs/latest/genai/eval-monitor/quickstart/)!
 
 ---
 
-_Learn more about MLflow's assessment capabilities in our [documentation](https://mlflow.org/docs/latest/genai/assessments/feedback/), or explore the [MLflow GitHub repository](https://github.com/mlflow/mlflow) to see what's coming next._
+_Learn more about MLflow's evaluation and monitoring capabilities in the [documentation](https://mlflow.org/docs/latest/genai/eval-monitor/), or explore the [MLflow GitHub repository](https://github.com/mlflow/mlflow) to see what's coming next._


### PR DESCRIPTION
Now that the eval docs have been merged, we can link directly: https://github.com/mlflow/mlflow/pull/17159