### PR TITLE
Update blog post frontmatter to include og:image tags

### DIFF
--- a/website/blog/2023-11-30-mlflow-autolog/index.md
+++ b/website/blog/2023-11-30-mlflow-autolog/index.md
@@ -4,6 +4,7 @@ slug: mlflow-autolog
 tags: [autolog]
 authors: [daniel-liden]
 thumbnail: /img/blog/mlflow-autolog.png
+image: /img/blog/mlflow-autolog.png
 ---
 
 Looking to learn more about the autologging functionality included in MLflow? Look no further than this primer on the basics of using this powerful and time-saving feature!

--- a/website/blog/2024-01-23-custom-pyfunc/index.md
+++ b/website/blog/2024-01-23-custom-pyfunc/index.md
@@ -5,6 +5,7 @@ slug: custom-pyfunc
 authors: [daniel-liden]
 tags: [pyfunc, models]
 thumbnail: /img/blog/custom-pyfunc.png
+image: /img/blog/custom-pyfunc.png
 ---
 
 If you're looking to learn about all of the flexibility and customization that is possible within

--- a/website/blog/2024-01-25-databricks-ce/index.md
+++ b/website/blog/2024-01-25-databricks-ce/index.md
@@ -3,6 +3,7 @@ title: Streamline your MLflow Projects with Free Hosted MLflow
 description: A guide to using Databricks Community Edition with integrated managed MLflow
 slug: databricks-ce
 thumbnail: /img/blog/databricks-ce.png
+image: /img/blog/databricks-ce.png
 authors: [abe-omorogbe]
 tags: [managed mlflow, getting started]
 ---

--- a/website/blog/2024-01-26-mlflow-year-in-review/index.md
+++ b/website/blog/2024-01-26-mlflow-year-in-review/index.md
@@ -5,6 +5,7 @@ slug: mlflow-year-in-review
 authors: [carly-akerly]
 tags: [MLflow, "2023", Linux Foundation]
 thumbnail: /img/blog/2023-year-in-review.png
+image: /img/blog/2023-year-in-review.png
 ---
 
 With more than **16 million** monthly downloads, MLflow has established itself as a leading open-source MLOps platform worldwide.

--- a/website/blog/2024-03-05-deep-learning-part-1/index.md
+++ b/website/blog/2024-03-05-deep-learning-part-1/index.md
@@ -5,6 +5,7 @@ slug: deep-learning-part-1
 authors: [abe-omorogbe, hubert-zub, yun-park, chen-qian, jesse-chan]
 tags: [Deep Learning]
 thumbnail: /img/blog/dl-chart-grouping.gif
+image: /img/blog/dl-chart-grouping.gif
 ---
 
 In the quickly evolving world of artificial intelligence, where generative AI has taken center stage, the landscape of machine learning is

--- a/website/blog/2024-04-26-deep-learning-part-2/index.md
+++ b/website/blog/2024-04-26-deep-learning-part-2/index.md
@@ -5,6 +5,7 @@ slug: deep-learning-part-2
 authors: [puneet-jain, avinash-sooriyarachchi, abe-omorogbe, ben]
 tags: [Deep Learning]
 thumbnail: /img/blog/dl-blog-2.png
+image: /img/blog/dl-blog-2.png
 ---
 
 In the realm of deep learning, finetuning of pre-trained Large Language Models (LLMs) on private datasets is an excellent customization

--- a/website/blog/2024-06-10-mlflow-tracing/index.md
+++ b/website/blog/2024-06-10-mlflow-tracing/index.md
@@ -4,6 +4,7 @@ tags: [tracing, genai, mlops]
 slug: mlflow-tracing
 authors: [mlflow-maintainers]
 thumbnail: /img/blog/trace-intro.gif
+image: /img/blog/trace-intro.gif
 ---
 
 We're excited to announce the release of a powerful new feature in MLflow: [MLflow Tracing](https://mlflow.org/docs/latest/llms/tracing/index.html).

--- a/website/blog/2024-07-26-pyfunc-in-practice/index.md
+++ b/website/blog/2024-07-26-pyfunc-in-practice/index.md
@@ -5,6 +5,7 @@ tags: [pyfunc, mlflow, ensemble-models]
 slug: pyfunc-in-practice
 authors: [hugo-carvalho, joana-ferreira, rahul-pandey, filipe-miranda]
 thumbnail: /img/blog/pyfunc-in-practice.png
+image: /img/blog/pyfunc-in-practice.png
 ---
 
 If you're looking to fully leverage the capabilities of `mlflow.pyfunc` and understand how it can be utilized in a Machine Learning project, this blog post will guide you through the process. MLflow PyFunc offers creative freedom and flexibility, allowing the development of complex systems encapsulated as models in MLflow that follow the same lifecycle as traditional ones. This blog will showcase how to create multi-model setups, seamlessly connect to databases, and implement your own custom fit method in your MLflow PyFunc model.

--- a/website/blog/2024-08-06-langgraph-model-from-code/index.md
+++ b/website/blog/2024-08-06-langgraph-model-from-code/index.md
@@ -4,6 +4,7 @@ tags: [genai, mlops]
 slug: langgraph-model-from-code
 authors: [michael-berk, mlflow-maintainers]
 thumbnail: /img/blog/release-candidates.png
+image: /img/blog/release-candidates.png
 ---
 
 In this blog, we'll guide you through creating a LangGraph chatbot using MLflow. By combining MLflow with LangGraph's ability to create and manage cyclical graphs, you can create powerful stateful, multi-actor applications in a scalable fashion.

--- a/website/blog/2024-08-29-autogen-pyfunc/index.md
+++ b/website/blog/2024-08-29-autogen-pyfunc/index.md
@@ -5,6 +5,7 @@ tags: [genai, mlops]
 slug: autogen-image-agent
 authors: [michael-berk, mlflow-maintainers]
 thumbnail: /img/blog/autogen-blog.png
+image: /img/blog/autogen-blog.png
 ---
 
 In this blog, we'll guide you through creating an [AutoGen](https://microsoft.github.io/autogen/) agent framework within an MLflow custom PyFunc. By combining MLflow with AutoGen's ability to create multi-agent frameworks, we are able to create scalable and stable GenAI applications.

--- a/website/blog/2024-09-13-models-from-code-logging/index.md
+++ b/website/blog/2024-09-13-models-from-code-logging/index.md
@@ -4,6 +4,7 @@ tags: [genai, pyfunc, mlops]
 slug: models_from_code
 authors: [awadelrahman-ahmed]
 thumbnail: /img/blog/thumbnail-models-from-code.gif
+image: /img/blog/thumbnail-models-from-code.gif
 ---
 
 We all (well, most of us) remember November 2022 when the public release of ChatGPT by OpenAI marked a significant turning point in the world of AI. While generative artificial intelligence (GenAI) had been evolving for some time, ChatGPT, built on OpenAI's GPT-3.5 architecture, quickly captured the public’s imagination. This led to an explosion of interest in GenAI, both within the tech industry and among the general public.

--- a/website/blog/2024-10-03-llm-as-judge/index.md
+++ b/website/blog/2024-10-03-llm-as-judge/index.md
@@ -5,6 +5,7 @@ slug: llm-as-judge
 authors: [pedro-azevedo, rahul-pandey]
 tags: [genai, mlflow-evalaute]
 thumbnail: /img/blog/llm-as-judge.png
+image: /img/blog/llm-as-judge.png
 ---
 
 In this blog post, we'll dive on a journey to revolutionize how we evaluate language models. We'll explore the power of MLflow Evaluate and harness the capabilities of Large Language Models (LLMs) as judges. By the end, you'll learn how to create custom metrics, implement LLM-based evaluation, and apply these techniques to real-world scenarios. Get ready to transform your model assessment process and gain deeper insights into your AI's performance!

--- a/website/blog/2024-10-25-llama-index-workflow/index.md
+++ b/website/blog/2024-10-25-llama-index-workflow/index.md
@@ -5,6 +5,7 @@ slug: mlflow-llama-index-workflow
 authors: [yuki-watanabe]
 tags: [genai, mlops, mlflow-evaluate]
 thumbnail: /img/blog/llama-index-thumbnail.png
+image: /img/blog/llama-index-thumbnail.png
 ---
 
 ![Thumbnail](llama_index_workflow_title.png)

--- a/website/blog/2024-11-07-bedrock-chat-model-part-1/index.md
+++ b/website/blog/2024-11-07-bedrock-chat-model-part-1/index.md
@@ -5,6 +5,7 @@ slug: bedrock-chat-model-part-1
 authors: [jas-bali]
 tags: [genai, pyfunc, bedrock, tracing]
 thumbnail: /img/blog/bedrock-chatmodel.png
+image: /img/blog/bedrock-chatmodel.png
 ---
 
 ![Thumbnail](bedrock_chatmodel.png)

--- a/website/blog/2024-12-20-mlflow-tracing-in-jupyter/index.md
+++ b/website/blog/2024-12-20-mlflow-tracing-in-jupyter/index.md
@@ -5,6 +5,7 @@ slug: mlflow-tracing-in-jupyter
 authors: [daniel-lok]
 tags: [genai, mlops, tracing]
 thumbnail: /img/blog/mlflow-tracing-in-jupyter.png
+image: /img/blog/mlflow-tracing-in-jupyter.png
 ---
 
 ![Thumbnail](mlflow-tracing-in-jupyter-title.png)

--- a/website/blog/2025-01-23-from-natural-language-to-sql/index.md
+++ b/website/blog/2025-01-23-from-natural-language-to-sql/index.md
@@ -13,6 +13,7 @@ authors:
   - joana-ferreira
   - rahul-pandey
 thumbnail: /img/blog/from-natural-language-to-sql.png
+image: /img/blog/from-natural-language-to-sql.png
 ---
 
 If you're looking to build a Multi-Lingual Query Engine that combines natural language to SQL generation with query execution while fully leveraging MLflow’s features, this blog post is your guide. We’ll explore how to leverage **MLflow Models from Code** to enable seamless tracking and versioning of AI Workflows. Additionally, we’ll deep dive into **MLflow’s Tracing** feature, which introduces observability into the many different components of an AI Workflow by tracking inputs, outputs, and metadata at every intermediate step.

--- a/website/blog/2025-01-30-custom-tracing-provider/index.md
+++ b/website/blog/2025-01-30-custom-tracing-provider/index.md
@@ -4,6 +4,7 @@ tags: [genai, tracing, ollama]
 slug: custom-tracing
 authors: [daniel-liden]
 thumbnail: /img/blog/tracing-new-provider.png
+image: /img/blog/tracing-new-provider.png
 ---
 
 In this post, we will show how to add MLflow Tracing to a new LLM provider by adding tracing support to the `chat` method of the Ollama Python SDK.

--- a/website/blog/2025-03-06-tracing-introduction/index.mdx
+++ b/website/blog/2025-03-06-tracing-introduction/index.mdx
@@ -5,6 +5,7 @@ slug: ai-observability-mlflow-tracing
 authors: [daniel-liden]
 tags: [genai, observability, tracing]
 thumbnail: /img/blog/tracing-intro-thumbnail.png
+image: /img/blog/tracing-intro-thumbnail.png
 ---
 
 import Tabs from "@theme/Tabs";

--- a/website/blog/2025-04-01-tlm-tracing/index.mdx
+++ b/website/blog/2025-04-01-tlm-tracing/index.mdx
@@ -5,6 +5,7 @@ slug: tlm-tracing
 authors: [chris-mauck]
 tags: [genai, observability, tracing]
 thumbnail: /img/blog/tlm-tracing-thumbnail.png
+image: /img/blog/tlm-tracing-thumbnail.png
 ---
 
 # Automatically find the bad LLM responses in your LLM Evals with Cleanlab

--- a/website/blog/2025-05-04-mlflow-image-datasets/index.md
+++ b/website/blog/2025-05-04-mlflow-image-datasets/index.md
@@ -4,6 +4,7 @@ tags: [mlflow, datasets, mlops, computer-vision]
 slug: tracking-image-datasets
 authors: [thorsteen]
 thumbnail: /img/blog/coco-dataset.png
+image: /img/blog/coco-dataset.png
 ---
 
 Dataset tracking is fundamental to building robust and reproducible machine learning models. Among all data types, images present unique tracking challenges due to their high dimensionality, variability, and storage requirements. In this post, we'll demonstrate how to effectively track image datasets using MLflow's experiment tracking capabilities and UI, providing you with practical techniques to enhance your computer vision workflows' tracking of data and models.

--- a/website/blog/2025-06-09-mlflow-3/index.md
+++ b/website/blog/2025-06-09-mlflow-3/index.md
@@ -4,6 +4,7 @@ tags: [mlflow, genai, tracing, evaluation, mlops]
 slug: mlflow-3-launch
 authors: [mlflow-maintainers]
 thumbnail: /img/blog/mlflow-3-trace-ui.png
+image: /img/blog/mlflow-3-trace-ui.png
 ---
 
 The open source MLflow community has reached a major milestone. Today, we're releasing **MLflow 3**, which brings production-ready generative AI capabilities to the platform that millions of developers trust for ML operations.

--- a/website/blog/2025-07-24-mlflow-typescript/index.mdx
+++ b/website/blog/2025-07-24-mlflow-typescript/index.mdx
@@ -4,6 +4,7 @@ tags: [mlflow, genai, tracing, evaluation, typescript]
 slug: mlflow-typescript
 authors: [mlflow-maintainers]
 thumbnail: /img/blog/mlflow-typescript-thumbnail.png
+image: /img/blog/mlflow-typescript-thumbnail.png
 ---
 
 <img

--- a/website/blog/2025-08-11-mlflow-assessment-ui/index.mdx
+++ b/website/blog/2025-08-11-mlflow-assessment-ui/index.mdx
@@ -4,6 +4,7 @@ tags: [mlflow, genai, tracing, evaluation]
 slug: mlflow-assessment-ui
 authors: [mlflow-maintainers]
 thumbnail: /img/blog/traces-tab.png
+image: /img/blog/traces-tab.png
 ---
 
 # Assessment-focused UIs in MLflow 3.3


### PR DESCRIPTION
See the documentation here:

https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-blog#image

This YAML key sets the og:image tag, which shows up in the previews of our social media posts when we link the blogs. For now I've just set them to be the same as the thumbnails we use.