### PR TITLE
Enforce image tag in blogposts

### DIFF
--- a/website/blog/2023-10-31-mlflow-docs-overhaul.md
+++ b/website/blog/2023-10-31-mlflow-docs-overhaul.md
@@ -4,6 +4,7 @@ tags: [docs]
 slug: mlflow-docs-overhaul
 authors: [mlflow-maintainers]
 thumbnail: /img/blog/docs-overhaul.png
+image: /img/blog/docs-overhaul.png
 ---
 
 The MLflow Documentation is getting an upgrade.

--- a/website/blog/2024-04-17-release-candidates.md
+++ b/website/blog/2024-04-17-release-candidates.md
@@ -4,6 +4,7 @@ tags: [mlflow]
 slug: release-candidates
 authors: [mlflow-maintainers]
 thumbnail: /img/blog/release-candidates.png
+image: /img/blog/release-candidates.png
 ---
 
 # Announcing MLflow Release Candidates

--- a/website/blog/2025-04-28-mlflow-go.md
+++ b/website/blog/2025-04-28-mlflow-go.md
@@ -4,6 +4,7 @@ tags: [mlflow]
 slug: mlflow-go
 authors: [florian-verdonck]
 thumbnail: /img/blog/mlflow-go.jpeg
+image: /img/blog/mlflow-go.jpeg
 ---
 
 The [MLflow project](https://mlflow.org) is a cornerstone of the machine learning community. It is highly flexible and makes machine learning workflows more reproducible, manageable and collaborative.

--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,7 @@
     "check-thumbnails": "ts-node scripts/check-thumbnails.ts",
     "check-authors": "ts-node scripts/check-authors.ts",
     "check-image-frontmatter": "ts-node scripts/check-image-frontmatter.ts",
-    "lint": "npm run check-thumbnails && npm run check-authors && npm run check-image-frontmatter",
+    "lint": "yarn check-thumbnails && yarn check-authors && yarn check-image-frontmatter",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,8 @@
     "compile": "ts-node scripts/compile.ts && prettier --write src/posts.ts",
     "check-thumbnails": "ts-node scripts/check-thumbnails.ts",
     "check-authors": "ts-node scripts/check-authors.ts",
+    "check-image-frontmatter": "ts-node scripts/check-image-frontmatter.ts",
+    "lint": "npm run check-thumbnails && npm run check-authors && npm run check-image-frontmatter",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",

--- a/website/scripts/check-image-frontmatter.ts
+++ b/website/scripts/check-image-frontmatter.ts
@@ -1,0 +1,108 @@
+import fs from "fs";
+import path from "path";
+
+function getMarkdownFiles(dir: string, fileList: string[] = []): string[] {
+  const files = fs.readdirSync(dir);
+
+  files.forEach((file) => {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+
+    if (stat.isDirectory()) {
+      getMarkdownFiles(filePath, fileList);
+    } else if (filePath.endsWith(".md") || filePath.endsWith(".mdx")) {
+      fileList.push(filePath);
+    }
+  });
+
+  return fileList;
+}
+
+function getBlogPostFiles(dir: string): string[] {
+  const files = fs.readdirSync(dir);
+  const blogPostFiles: string[] = [];
+
+  files.forEach((file) => {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+
+    if (stat.isDirectory()) {
+      // Check for index.md or index.mdx in subdirectories
+      const indexMd = path.join(filePath, "index.md");
+      const indexMdx = path.join(filePath, "index.mdx");
+      
+      if (fs.existsSync(indexMd)) {
+        blogPostFiles.push(indexMd);
+      } else if (fs.existsSync(indexMdx)) {
+        blogPostFiles.push(indexMdx);
+      }
+    } else if (file.endsWith(".md") || file.endsWith(".mdx")) {
+      // Direct markdown files in blog directory
+      blogPostFiles.push(filePath);
+    }
+  });
+
+  return blogPostFiles;
+}
+
+function extractFrontmatter(content: string): Record<string, any> {
+  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---/;
+  const match = content.match(frontmatterRegex);
+  
+  if (!match) {
+    return {};
+  }
+
+  const frontmatterContent = match[1];
+  const frontmatter: Record<string, any> = {};
+  
+  // Simple YAML parsing for key: value pairs
+  frontmatterContent.split('\n').forEach(line => {
+    const trimmedLine = line.trim();
+    if (trimmedLine && !trimmedLine.startsWith('#')) {
+      const colonIndex = trimmedLine.indexOf(':');
+      if (colonIndex > 0) {
+        const key = trimmedLine.substring(0, colonIndex).trim();
+        const value = trimmedLine.substring(colonIndex + 1).trim();
+        frontmatter[key] = value;
+      }
+    }
+  });
+
+  return frontmatter;
+}
+
+function checkForImageFrontmatter(filePaths: string[]): string[] {
+  const filesWithoutImage: string[] = [];
+
+  filePaths.forEach((filePath) => {
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+    const frontmatter = extractFrontmatter(fileContent);
+    
+    // Check if the image field is missing or empty
+    if (!frontmatter.image || frontmatter.image.trim() === '') {
+      filesWithoutImage.push(filePath);
+    }
+  });
+
+  return filesWithoutImage;
+}
+
+const blogPostFiles = getBlogPostFiles("./blog");
+const filesWithoutImage = checkForImageFrontmatter(blogPostFiles);
+
+console.log(`Checked ${blogPostFiles.length} blog posts for 'image' frontmatter field.`);
+
+if (filesWithoutImage.length > 0) {
+  console.log("Found blog posts missing 'image' frontmatter field:");
+  filesWithoutImage.forEach(file => console.log(`  - ${file}`));
+  console.log("\nAll blog posts must include an 'image' field in their YAML frontmatter.");
+  console.log("Example:");
+  console.log("---");
+  console.log("title: Your Blog Post Title");
+  console.log("image: /img/blog/your-post-image.png");
+  console.log("---");
+  process.exit(1);
+} else {
+  console.log("✅ All blog posts have the required 'image' frontmatter field.");
+}

--- a/website/scripts/check-image-frontmatter.ts
+++ b/website/scripts/check-image-frontmatter.ts
@@ -1,23 +1,6 @@
 import fs from "fs";
 import path from "path";
 
-function getMarkdownFiles(dir: string, fileList: string[] = []): string[] {
-  const files = fs.readdirSync(dir);
-
-  files.forEach((file) => {
-    const filePath = path.join(dir, file);
-    const stat = fs.statSync(filePath);
-
-    if (stat.isDirectory()) {
-      getMarkdownFiles(filePath, fileList);
-    } else if (filePath.endsWith(".md") || filePath.endsWith(".mdx")) {
-      fileList.push(filePath);
-    }
-  });
-
-  return fileList;
-}
-
 function getBlogPostFiles(dir: string): string[] {
   const files = fs.readdirSync(dir);
   const blogPostFiles: string[] = [];
@@ -30,7 +13,7 @@ function getBlogPostFiles(dir: string): string[] {
       // Check for index.md or index.mdx in subdirectories
       const indexMd = path.join(filePath, "index.md");
       const indexMdx = path.join(filePath, "index.mdx");
-      
+
       if (fs.existsSync(indexMd)) {
         blogPostFiles.push(indexMd);
       } else if (fs.existsSync(indexMdx)) {
@@ -48,19 +31,19 @@ function getBlogPostFiles(dir: string): string[] {
 function extractFrontmatter(content: string): Record<string, any> {
   const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---/;
   const match = content.match(frontmatterRegex);
-  
+
   if (!match) {
     return {};
   }
 
   const frontmatterContent = match[1];
   const frontmatter: Record<string, any> = {};
-  
+
   // Simple YAML parsing for key: value pairs
-  frontmatterContent.split('\n').forEach(line => {
+  frontmatterContent.split("\n").forEach((line) => {
     const trimmedLine = line.trim();
-    if (trimmedLine && !trimmedLine.startsWith('#')) {
-      const colonIndex = trimmedLine.indexOf(':');
+    if (trimmedLine && !trimmedLine.startsWith("#")) {
+      const colonIndex = trimmedLine.indexOf(":");
       if (colonIndex > 0) {
         const key = trimmedLine.substring(0, colonIndex).trim();
         const value = trimmedLine.substring(colonIndex + 1).trim();
@@ -78,9 +61,9 @@ function checkForImageFrontmatter(filePaths: string[]): string[] {
   filePaths.forEach((filePath) => {
     const fileContent = fs.readFileSync(filePath, "utf-8");
     const frontmatter = extractFrontmatter(fileContent);
-    
+
     // Check if the image field is missing or empty
-    if (!frontmatter.image || frontmatter.image.trim() === '') {
+    if (!frontmatter.image || frontmatter.image.trim() === "") {
       filesWithoutImage.push(filePath);
     }
   });
@@ -91,18 +74,16 @@ function checkForImageFrontmatter(filePaths: string[]): string[] {
 const blogPostFiles = getBlogPostFiles("./blog");
 const filesWithoutImage = checkForImageFrontmatter(blogPostFiles);
 
-console.log(`Checked ${blogPostFiles.length} blog posts for 'image' frontmatter field.`);
-
 if (filesWithoutImage.length > 0) {
   console.log("Found blog posts missing 'image' frontmatter field:");
-  filesWithoutImage.forEach(file => console.log(`  - ${file}`));
-  console.log("\nAll blog posts must include an 'image' field in their YAML frontmatter.");
+  filesWithoutImage.forEach((file) => console.log(`  - ${file}`));
+  console.log(
+    "\nAll blog posts must include an 'image' field in their YAML frontmatter. This sets the og:image metadata tag, which is used for preview images in various social media platforms.",
+  );
   console.log("Example:");
   console.log("---");
   console.log("title: Your Blog Post Title");
   console.log("image: /img/blog/your-post-image.png");
   console.log("---");
   process.exit(1);
-} else {
-  console.log("✅ All blog posts have the required 'image' frontmatter field.");
 }


### PR DESCRIPTION
Implement a lint rule to enforce image metadata. The job caught 3 files without the tag, they must have gotten missed  in the previous PR due to not being contained within a folder

Sample output:
```
$ yarn lint
yarn run v1.22.18
$ npm run check-thumbnails && npm run check-authors && npm run check-image-frontmatter

> website@0.0.0 check-thumbnails
> ts-node scripts/check-thumbnails.ts


> website@0.0.0 check-authors
> ts-node scripts/check-authors.ts


> website@0.0.0 check-image-frontmatter
> ts-node scripts/check-image-frontmatter.ts

Found blog posts missing 'image' frontmatter field:
  - blog/2025-04-28-mlflow-go.md

All blog posts must include an 'image' field in their YAML frontmatter. This sets the og:image metadata tag, which is used for preview images in various social media platforms.
Example:
---
title: Your Blog Post Title
image: /img/blog/your-post-image.png
---
```