### PR TITLE
Fix RC link in blog post

### DIFF
--- a/website/blog/2025-08-11-mlflow-assessment-ui/index.mdx
+++ b/website/blog/2025-08-11-mlflow-assessment-ui/index.mdx
@@ -44,7 +44,7 @@ With assessments now prominently displayed in the Traces tab, production monitor
 
 ## Getting Started
 
-The new assessment features will be available in MLflow 3.3, and if you'd like an early preview, you can install the [MLflow 3.3.0rc0](https://mlflow.org/releases/3.3.0rc0) release candidate. If you're already using MLflow's tracing capabilities, the enhanced UI will automatically display any existing assessments you've logged.
+The new assessment features will be available in MLflow 3.3, and if you'd like an early preview, you can install the [MLflow 3.3.0rc0](https://pypi.org/project/mlflow/3.3.0rc0/) release candidate. If you're already using MLflow's tracing capabilities, the enhanced UI will automatically display any existing assessments you've logged.
 
 To start leveraging these new capabilities:
 


### PR DESCRIPTION
As title, forgot we don't create a release post for RCs. Link to pypi page instead