### PR TITLE
Disallow crawling any non-latest documentations

### DIFF
--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -8,6 +8,7 @@ Allow: /docs/latest/
 # Disallow all legacy documentation versions
 Disallow: /docs/1.*/
 Disallow: /docs/2.*/
+Disallow: /docs/3.*/
 Disallow: /docs/0.*/
 
 # Specific rules for AI crawlers
@@ -17,6 +18,7 @@ User-agent: GPTBot
 Allow: /docs/latest/
 Disallow: /docs/1.*/
 Disallow: /docs/2.*/
+Disallow: /docs/3.*/
 Disallow: /docs/0.*/
 
 # Google Gemini
@@ -24,6 +26,7 @@ User-agent: Google-Extended
 Allow: /docs/latest/
 Disallow: /docs/1.*/
 Disallow: /docs/2.*/
+Disallow: /docs/3.*/
 Disallow: /docs/0.*/
 
 # Anthropic Claude
@@ -32,6 +35,7 @@ User-agent: Claude-Web
 Allow: /docs/latest/
 Disallow: /docs/1.*/
 Disallow: /docs/2.*/
+Disallow: /docs/3.*/
 Disallow: /docs/0.*/
 
 # Common Crawl (used by many AI systems)
@@ -39,6 +43,7 @@ User-agent: CCBot
 Allow: /docs/latest/
 Disallow: /docs/1.*/
 Disallow: /docs/2.*/
+Disallow: /docs/3.*/
 Disallow: /docs/0.*/
 
 # Perplexity
@@ -53,6 +58,7 @@ User-agent: cohere-ai
 Allow: /docs/latest/
 Disallow: /docs/1.*/
 Disallow: /docs/2.*/
+Disallow: /docs/3.*/
 Disallow: /docs/0.*/
 
 # Sitemap location


### PR DESCRIPTION
The current `robots.txt` does not explicitly block crawling of non-latest `3.x` versions. This causes an issue like the top result from `MLflow documentation` returns 3.2 doc, which lacks lots of new features.