### PR TITLE
Corrected ambassador's company typo name

### DIFF
--- a/website/src/pages/ambassadors.json
+++ b/website/src/pages/ambassadors.json
@@ -75,7 +75,7 @@
     {
       "title": "Koyelia Ghosh Roy",
       "role": "Director Gen AI and Agentic AI Delivery Leader",
-      "company": "Capegemini",
+      "company": "Capgemini",
       "img": "/img/ambassadors/Koyelia Ghosh Roy.jpg"
     }
   ],


### PR DESCRIPTION
- Correct an Ambassador's company name typo
- Capegemini --> Capgemini