### PR TITLE
Fix CI by installing uv for docs build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
+      - uses: astral-sh/setup-uv@v5
       - name: Build docs
         # Only build docs for main branch, otherwise
         # the build will take a long time.


### PR DESCRIPTION
## Summary

The MLflow docs build now requires `uv` for the `yarn convert-notebooks` command. This PR adds the `astral-sh/setup-uv` action to install it in CI.

Fixes https://github.com/mlflow/mlflow-website/actions/runs/21503396506/job/61954327567

🤖 Generated with [Claude Code](https://claude.com/claude-code)