### PR TITLE
Use require() for video assets in 3.9.0 release notes

### DIFF
--- a/website/releases/2026-01-30-3.9.0-release.md
+++ b/website/releases/2026-01-30-3.9.0-release.md
@@ -10,7 +10,7 @@ MLflow 3.9.0 is a major release focused on AI Observability and Evaluation capab
 ## 1. MLflow Assistant Powered by Claude Code
 
 <video controls autoplay muted loop playsinline width="100%">
-  <source src="/img/releases/3.9.0/mlflow_assistant.mp4" type="video/mp4" />
+  <source src={require("/img/releases/3.9.0/mlflow_assistant.mp4").default} type="video/mp4" />
 </video>
 
 MLflow Assistant transforms coding agents like Claude Code into experienced AI engineers by your side. Unlike typical chatbots, the assistant is **aware of your codebase and context**—it's not just a Q&A tool, but a full-fledged AI engineer that can find root causes for issues, set up quality tests, and apply LLMOps best practices to your project.
@@ -68,7 +68,7 @@ result = optimized_judge.evaluate(trace)
 ## 4. Configuring and Building a Judge with Judge Builder UI
 
 <video controls autoplay muted loop playsinline width="100%">
-  <source src="/img/releases/3.9.0/judge_builder_ui.mp4" type="video/mp4" />
+  <source src={require("/img/releases/3.9.0/judge_builder_ui.mp4").default} type="video/mp4" />
 </video>
 
 A new visual interface lets you create and test custom LLM judge prompts without writing code. Iterate quickly on judge criteria and scoring rubrics with immediate feedback, test judges on sample traces before deploying to production, and export validated judges to the Python SDK for programmatic integration.


### PR DESCRIPTION
## Summary
- Use webpack `require()` for video sources in the 3.9.0 release notes
- Ensures proper asset bundling during build

## Test plan
- [x] `yarn build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)