### PR TITLE
Add preinstall script to enforce npm usage

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "website",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/faster": "3.9.2",

--- a/website/package.json
+++ b/website/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "preinstall": "npx only-allow npm",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",


### PR DESCRIPTION
## Summary

After migrating from yarn to npm (#455), this PR adds a preinstall hook using `only-allow` to prevent accidental usage of yarn or pnpm. Running `yarn install` or `pnpm install` will now fail with a clear message directing users to use npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)