### PR TITLE
Convert sitemap to an index and link docs sitemap

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -13,6 +13,10 @@ const config: Config = {
   // tagline: 'Dinosaurs are cool',
   favicon: "img/mlflow-favicon.ico",
 
+  // ensure trailing slash is present in the sitemap, this fixes some URLs like
+  // https://mlflow.org/releases/3.3.0 which are broken without a slash
+  trailingSlash: true,
+
   // Set the production url of your site here
   url: "https://mlflow.org",
   // Set the /<baseUrl>/ pathname under which your site is served

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -88,6 +88,9 @@ const config: Config = {
           trackingID: "AW-16857946923",
           anonymizeIP: true,
         },
+        sitemap: {
+          filename: "sitemap-website.xml",
+        },
       } satisfies Preset.Options,
     ],
   ],

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -63,3 +63,4 @@ Disallow: /docs/0.*/
 
 # Sitemap location
 Sitemap: https://mlflow.org/sitemap.xml
+Sitemap: https://mlflow.org/docs/latest/sitemap.xml

--- a/website/static/sitemap.xml
+++ b/website/static/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://mlflow.org/sitemap-website.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://mlflow.org/docs/latest/sitemap.xml</loc>
+  </sitemap>
+</sitemapindex>


### PR DESCRIPTION
Currently `mlflow.org/sitemap.xml` only contains links to the the top-level site, and not to our docs.

This is because the two are actually generated by separate docusaurus instances. This PR creates a static, unchanging `sitemap.xml` that simply lists the two docusaurus-generated sitemaps as index entries. Now when submitting `sitemap.xml` to Google, both main and docs sitemaps should be indexed.

ref: https://developers.google.com/search/docs/crawling-indexing/sitemaps/large-sitemaps

check the maps at:

https://pr-559--test-mlflow-website.netlify.app/sitemap.xml
https://pr-559--test-mlflow-website.netlify.app/sitemap-website.xml
(docs one won't show up here as the required files don't exist, but it is at https://mlflow.org/docs/latest/sitemap.xml)