### PR TITLE
Updated typo for braintrust vs mlflow blog

### DIFF
--- a/website/src/pages/braintrust-alternative.tsx
+++ b/website/src/pages/braintrust-alternative.tsx
@@ -640,7 +640,7 @@ export default function BraintrustAlternative() {
             models that enables teams to debug, evaluate, monitor, and optimize
             production-quality AI applications while controlling costs and
             managing access to models and data. MLflow is 100% open source under
-            the Apache 2.0 license and governed by the{" "}
+            the Apache 2.0 license and{" "}
             <strong>
               backed by the{" "}
               <Link href="https://www.linuxfoundation.org/">


### PR DESCRIPTION
Fix the sentence: 
<img width="930" height="222" alt="image" src="https://github.com/user-attachments/assets/276a7a77-f7f7-4ce8-8e88-6fd4de58f989" />
