### PR TITLE
Updating website to include Try Demo

### DIFF
--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -37,7 +37,7 @@ const GitHubStarsBadge = () => {
 };
 
 import "./Header.module.css";
-import { MLFLOW_DOCS_URL } from "@site/src/constants";
+import { MLFLOW_DOCS_URL, MLFLOW_TRY_DEMO_URL } from "@site/src/constants";
 import { cva } from "class-variance-authority";
 
 const MD_BREAKPOINT = 640;
@@ -176,8 +176,13 @@ export const Header = () => {
           <div className="flex flex-row items-center gap-3 md:order-2 md:gap-4 rtl:space-x-reverse grow justify-end basis-0">
             <GitHubStarsBadge />
             <Link href={getStartedHref} className="hidden md:block">
+              <Button variant="outline" size="small">
+                Get Started
+              </Button>
+            </Link>
+            <Link href={MLFLOW_TRY_DEMO_URL} className="hidden md:block">
               <Button variant="primary" size="small">
-                Get started
+                Try Demo
               </Button>
             </Link>
             <button
@@ -323,10 +328,15 @@ export const Header = () => {
             >
               <HeaderMenuItem label="Resources" hasDropdown />
             </li>
-            <li className="w-full md:w-auto md:hidden">
+            <li className="w-full md:w-auto md:hidden flex flex-col gap-2">
               <Link href={getStartedHref}>
+                <Button variant="outline" size="small" width="full">
+                  Get Started
+                </Button>
+              </Link>
+              <Link href={MLFLOW_TRY_DEMO_URL}>
                 <Button variant="primary" size="small" width="full">
-                  Get started
+                  Try Demo
                 </Button>
               </Link>
             </li>

--- a/website/src/constants.ts
+++ b/website/src/constants.ts
@@ -1,5 +1,6 @@
 export const MOBILE_LAYOUT_BREAKPOINT = 996;
 export const MLFLOW_DOCS_URL = "https://mlflow.org/docs/latest/";
+export const MLFLOW_TRY_DEMO_URL = "https://demo.mlflow.org/";
 export const MLFLOW_GENAI_DOCS_URL = "https://mlflow.org/docs/latest/genai/";
 export const MLFLOW_ML_DOCS_URL = "https://mlflow.org/docs/latest/ml/";
 export const MLFLOW_DBX_TRIAL_URL =

--- a/website/src/pages/classical-ml/index.tsx
+++ b/website/src/pages/classical-ml/index.tsx
@@ -1,4 +1,7 @@
-import { MLFLOW_ML_DOCS_URL } from "@site/src/constants";
+import {
+  MLFLOW_ML_DOCS_URL,
+  MLFLOW_TRY_DEMO_URL,
+} from "@site/src/constants";
 import Head from "@docusaurus/Head";
 import Link from "@docusaurus/Link";
 import {
@@ -83,14 +86,14 @@ export default function ClassicalML(): JSX.Element {
           actions={
             <div className="flex flex-col items-center gap-4">
               <div className="flex flex-wrap justify-center items-center gap-4">
-                <Link to="#get-started">
+                <Link to={MLFLOW_TRY_DEMO_URL}>
                   <Button variant="primary" size="medium">
-                    Get Started
+                    Try Demo
                   </Button>
                 </Link>
-                <Link to={MLFLOW_ML_DOCS_URL}>
+                <Link to="#get-started">
                   <Button variant="outline" size="medium">
-                    View Docs
+                    Get Started
                   </Button>
                 </Link>
               </div>

--- a/website/src/pages/classical-ml/index.tsx
+++ b/website/src/pages/classical-ml/index.tsx
@@ -1,7 +1,4 @@
-import {
-  MLFLOW_ML_DOCS_URL,
-  MLFLOW_TRY_DEMO_URL,
-} from "@site/src/constants";
+import { MLFLOW_ML_DOCS_URL, MLFLOW_TRY_DEMO_URL } from "@site/src/constants";
 import Head from "@docusaurus/Head";
 import Link from "@docusaurus/Link";
 import {

--- a/website/src/pages/cn.tsx
+++ b/website/src/pages/cn.tsx
@@ -14,7 +14,7 @@ import { Section } from "../components/Section/Section";
 import { StickyFeaturesGrid } from "../components/ProductTabs/StickyFeaturesGrid";
 import type { Feature } from "../components/ProductTabs/features";
 import Link from "@docusaurus/Link";
-import { MLFLOW_DOCS_URL } from "../constants";
+import { MLFLOW_DOCS_URL, MLFLOW_TRY_DEMO_URL } from "../constants";
 import Head from "@docusaurus/Head";
 import clsx from "clsx";
 import { motion, AnimatePresence } from "motion/react";
@@ -539,12 +539,12 @@ export default function ChinesePage(): JSX.Element {
             </>
           }
           primaryCTA={{
-            label: "开始使用",
-            href: "#get-started",
+            label: "试用演示",
+            href: MLFLOW_TRY_DEMO_URL,
           }}
           secondaryCTA={{
-            label: "查看文档",
-            href: MLFLOW_DOCS_URL,
+            label: "开始使用",
+            href: "#get-started",
           }}
         >
           <TrustPills />

--- a/website/src/pages/genai/index.tsx
+++ b/website/src/pages/genai/index.tsx
@@ -15,7 +15,10 @@ import {
 } from "../../components";
 import { StickyFeaturesGrid } from "../../components/ProductTabs/StickyFeaturesGrid";
 import { categories } from "../../components/ProductTabs/features";
-import { MLFLOW_GENAI_DOCS_URL } from "@site/src/constants";
+import {
+  MLFLOW_GENAI_DOCS_URL,
+  MLFLOW_TRY_DEMO_URL,
+} from "@site/src/constants";
 import { TrustPills } from "../../components/TrustPills/TrustPills";
 import type { EcosystemItem } from "../../components/EcosystemList/EcosystemList";
 
@@ -340,14 +343,14 @@ export default function GenAi(): JSX.Element {
           actions={
             <div className="flex flex-col items-center gap-4">
               <div className="flex flex-wrap justify-center items-center gap-4">
-                <Link to="#get-started">
+                <Link to={MLFLOW_TRY_DEMO_URL}>
                   <Button variant="primary" size="medium">
-                    Get Started
+                    Try Demo
                   </Button>
                 </Link>
-                <Link to={MLFLOW_GENAI_DOCS_URL}>
+                <Link to="#get-started">
                   <Button variant="outline" size="medium">
-                    View Docs
+                    Get Started
                   </Button>
                 </Link>
               </div>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -14,7 +14,7 @@ import {
   TrustPills,
 } from "../components";
 import Link from "@docusaurus/Link";
-import { MLFLOW_DOCS_URL } from "../constants";
+import { MLFLOW_TRY_DEMO_URL } from "../constants";
 import Head from "@docusaurus/Head";
 
 const SEO_TITLE = "MLflow - Open Source AI Platform for Agents, LLMs & Models";
@@ -107,12 +107,12 @@ export default function Home(): JSX.Element {
             </>
           }
           primaryCTA={{
-            label: "Get Started",
-            href: `#get-started`,
+            label: "Try Demo",
+            href: MLFLOW_TRY_DEMO_URL,
           }}
           secondaryCTA={{
-            label: "View Docs",
-            href: MLFLOW_DOCS_URL,
+            label: "Get Started",
+            href: `#get-started`,
           }}
         >
           <TrustPills />

--- a/website/src/pages/jp.tsx
+++ b/website/src/pages/jp.tsx
@@ -14,7 +14,7 @@ import { Section } from "../components/Section/Section";
 import { StickyFeaturesGrid } from "../components/ProductTabs/StickyFeaturesGrid";
 import type { Feature } from "../components/ProductTabs/features";
 import Link from "@docusaurus/Link";
-import { MLFLOW_DOCS_URL } from "../constants";
+import { MLFLOW_DOCS_URL, MLFLOW_TRY_DEMO_URL} from "../constants";
 import Head from "@docusaurus/Head";
 import clsx from "clsx";
 import { motion, AnimatePresence } from "motion/react";
@@ -543,12 +543,12 @@ export default function JapanesePage(): JSX.Element {
             </>
           }
           primaryCTA={{
-            label: "はじめる",
-            href: "#get-started",
+            label: "デモをお試しください",
+            href: MLFLOW_TRY_DEMO_URL,
           }}
           secondaryCTA={{
-            label: "ドキュメントを見る",
-            href: MLFLOW_DOCS_URL,
+            label: "はじめる",
+            href: "#get-started",
           }}
         >
           <TrustPills />

--- a/website/src/pages/jp.tsx
+++ b/website/src/pages/jp.tsx
@@ -14,7 +14,7 @@ import { Section } from "../components/Section/Section";
 import { StickyFeaturesGrid } from "../components/ProductTabs/StickyFeaturesGrid";
 import type { Feature } from "../components/ProductTabs/features";
 import Link from "@docusaurus/Link";
-import { MLFLOW_DOCS_URL, MLFLOW_TRY_DEMO_URL} from "../constants";
+import { MLFLOW_DOCS_URL, MLFLOW_TRY_DEMO_URL } from "../constants";
 import Head from "@docusaurus/Head";
 import clsx from "clsx";
 import { motion, AnimatePresence } from "motion/react";


### PR DESCRIPTION
- Added "Try Demo" button as primary CTA
- Removed "View Docs" button
- Changes are applied to both homepages and the header

Screenshots:

<img width="1412" height="707" alt="Screenshot 2026-05-08 at 5 12 25 PM" src="https://github.com/user-attachments/assets/ec97fac7-bbe3-49ae-a58f-1800b3a17c6f" />
