### PR TITLE
Adding Try Demo link to llm product feature panels

### DIFF
--- a/website/src/components/ProductTabs/StickyFeaturesGrid.tsx
+++ b/website/src/components/ProductTabs/StickyFeaturesGrid.tsx
@@ -23,8 +23,16 @@ const interpolateColor = (color1: string, color2: string, factor: number) => {
   return `rgb(${r}, ${g}, ${b})`;
 };
 
-/** QuickstartLink component with animated glow effect. */
-const QuickstartLink = ({ href }: { href: string }) => (
+/** Animated pill link with a glow effect, used for Quickstart and Try Demo. */
+const GlowLink = ({
+  href,
+  label,
+  gradient,
+}: {
+  href: string;
+  label: string;
+  gradient: string;
+}) => (
   <motion.a
     href={href}
     target="_blank"
@@ -35,8 +43,7 @@ const QuickstartLink = ({ href }: { href: string }) => (
     <motion.span
       className="absolute inset-0 rounded-md -z-10"
       style={{
-        background:
-          "linear-gradient(135deg, rgba(59, 130, 246, 0.3), rgba(168, 85, 247, 0.3))",
+        background: gradient,
         filter: "blur(8px)",
       }}
       animate={{
@@ -49,7 +56,7 @@ const QuickstartLink = ({ href }: { href: string }) => (
         ease: "easeInOut",
       }}
     />
-    <span className="relative z-10 text-white px-3 py-1">Quickstart</span>
+    <span className="relative z-10 text-white px-3 py-1">{label}</span>
     <motion.span
       className="relative z-10 text-white pr-2"
       variants={{
@@ -59,6 +66,22 @@ const QuickstartLink = ({ href }: { href: string }) => (
       →
     </motion.span>
   </motion.a>
+);
+
+const QuickstartLink = ({ href }: { href: string }) => (
+  <GlowLink
+    href={href}
+    label="Quickstart"
+    gradient="linear-gradient(135deg, rgba(59, 130, 246, 0.3), rgba(168, 85, 247, 0.3))"
+  />
+);
+
+const TryDemoLink = ({ href }: { href: string }) => (
+  <GlowLink
+    href={href}
+    label="Try Demo"
+    gradient="linear-gradient(135deg, rgba(16, 185, 129, 0.3), rgba(6, 182, 212, 0.3))"
+  />
 );
 
 /** Left‑side text panel – sticks while scrolling. */
@@ -83,9 +106,15 @@ const FeatureTextSection = ({
         <p className="leading-relaxed" style={{ color: descColor }}>
           {feature.description}
         </p>
-        {feature.quickstartLink && (
-          <div style={{ opacity: visibility }}>
-            <QuickstartLink href={feature.quickstartLink} />
+        {(feature.quickstartLink || feature.tryDemoLink) && (
+          <div
+            className="flex flex-col items-start gap-5"
+            style={{ opacity: visibility }}
+          >
+            {feature.quickstartLink && (
+              <QuickstartLink href={feature.quickstartLink} />
+            )}
+            {feature.tryDemoLink && <TryDemoLink href={feature.tryDemoLink} />}
           </div>
         )}
       </div>

--- a/website/src/components/ProductTabs/features.tsx
+++ b/website/src/components/ProductTabs/features.tsx
@@ -24,6 +24,7 @@ export type Feature = {
   imageZoom?: number;
   imagePosition?: string;
   quickstartLink?: string;
+  tryDemoLink?: string;
   codeSnippet: string;
   codeLanguage?: "python" | "typescript";
   fullBleedImage?: boolean;
@@ -71,6 +72,8 @@ const llmAgentFeatures: Feature[] = [
     imageSrc: TracingTabImg,
     imageZoom: 160,
     quickstartLink: "https://mlflow.org/docs/latest/genai/tracing/quickstart/",
+    tryDemoLink:
+      "https://demo.mlflow.org/#/experiments/1/traces?startTimeLabel=CUSTOM&startTime=2026-04-17T16%3A47%3A15.258Z&endTime=2026-04-24T21%3A20%3A50.781Z",
     codeSnippet: `import mlflow
 import openai
 
@@ -125,6 +128,8 @@ response = client.chat.completions.create(
     ],
     quickstartLink:
       "https://mlflow.org/docs/latest/genai/eval-monitor/quickstart/",
+    tryDemoLink:
+      "https://demo.mlflow.org/#/experiments/1/runs/d690ad8bb7a546c5a74b79691bb32b27/evaluations",
     codeSnippet: `import mlflow
 from mlflow.genai.scorers import Correctness
 
@@ -168,6 +173,8 @@ results = mlflow.genai.evaluate(
     imageSrc: PromptTabImg,
     imageZoom: 150,
     quickstartLink: "https://mlflow.org/docs/latest/genai/prompt-registry/",
+    tryDemoLink:
+      "https://demo.mlflow.org/#/experiments/1/prompts/mlflow-demo.prompts.code-reviewer?promptVersion=4",
     codeSnippet: `import mlflow
 
 # Register a prompt template


### PR DESCRIPTION
- Adding Demo Link in LLM product feature panels (i.e. Observability / Evaluation / Prompts & Optimization).
- Links are synced with this related [PR 23127](https://github.com/mlflow/mlflow/pull/23127) that updates the demo links into README.md

Changes:

<img width="1409" height="516" alt="Screenshot 2026-05-11 at 3 48 31 PM" src="https://github.com/user-attachments/assets/b4111102-26e3-446d-807b-187f5eb0dbe2" />
