### PR TITLE
ci: add explicit read-only permissions to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,9 @@ on:
     # Run this job daily to detect dead slack invite links
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: contents: read` to the CI and e2e workflows. Both workflows check out code and run tests without needing write access. Declaring explicit permissions follows the principle of least privilege and limits exposure.