### PR TITLE
Advertise `mlflow agent setup` with a copyable command in the homepage hero

### DIFF
--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -179,6 +179,9 @@ export const Header = () => {
 
   return (
     <nav className={navStyles({ isOpen })}>
+      {/* Announcement banner for `mlflow agent setup`. Hidden on mobile
+          because the copy wraps poorly at narrow widths; dismissal is
+          remembered in localStorage. */}
       {isBannerVisible && (
         <div className="relative hidden md:flex items-center justify-center gap-2 w-full bg-gradient-to-r from-[#1e1b4b] to-[#4c1d95] text-white text-center text-sm px-6 py-2">
           <span>

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -14,6 +14,7 @@ import { HeaderMenuItem } from "../HeaderMenuItem/HeaderMenuItem";
 import { HeaderProductsSubmenu } from "../HeaderProductsSubmenu/HeaderProductsSubmenu";
 import { HeaderDocsSubmenu } from "../HeaderDocsSubmenu/HeaderDocsSubmenu";
 import { HeaderResourcesSubmenu } from "../HeaderResourcesSubmenu/HeaderResourcesSubmenu";
+import { CopyButton } from "../CodeSnippet/CopyButton";
 
 const GitHubStarsBadge = () => {
   const stars = useGitHubStars();
@@ -164,6 +165,21 @@ export const Header = () => {
 
   return (
     <nav className={navStyles({ isOpen })}>
+      <div className="flex items-center justify-center gap-2 w-full bg-gradient-to-r from-[#0194e2] to-[#7a3bff] text-white text-center text-sm px-6 py-2">
+        <span>
+          ✨ New: Let your coding agent set up MLflow for you:{" "}
+          <code className="rounded bg-black/25 px-1.5 py-0.5 font-mono">
+            uvx mlflow agent setup
+          </code>
+        </span>
+        <CopyButton code="uvx mlflow agent setup" />
+        <Link
+          href={MLFLOW_DOCS_URL}
+          className="underline font-medium text-white hover:text-white/80"
+        >
+          Learn more
+        </Link>
+      </div>
       <div className="flex flex-wrap items-center mx-auto px-6 lg:px-20 py-2 max-w-container">
         <div className="md:contents flex flex-row justify-between w-full sticky top-[8px]">
           <Link

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -180,7 +180,7 @@ export const Header = () => {
   return (
     <nav className={navStyles({ isOpen })}>
       {isBannerVisible && (
-        <div className="relative flex items-center justify-center gap-2 w-full bg-gradient-to-r from-[#1e1b4b] to-[#4c1d95] text-white text-center text-sm px-6 py-2">
+        <div className="relative hidden md:flex items-center justify-center gap-2 w-full bg-gradient-to-r from-[#1e1b4b] to-[#4c1d95] text-white text-center text-sm px-6 py-2">
           <span>
             ✨ New: Let your coding agent set up MLflow tracing for you:{" "}
             <code className="rounded bg-black/25 px-1.5 py-0.5 font-mono">

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -167,7 +167,7 @@ export const Header = () => {
     <nav className={navStyles({ isOpen })}>
       <div className="flex items-center justify-center gap-2 w-full bg-gradient-to-r from-[#0194e2] to-[#7a3bff] text-white text-center text-sm px-6 py-2">
         <span>
-          ✨ New: Let your coding agent set up MLflow for you:{" "}
+          ✨ New: Let your coding agent set up MLflow tracing for you:{" "}
           <code className="rounded bg-black/25 px-1.5 py-0.5 font-mono">
             uvx mlflow agent setup
           </code>

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -180,7 +180,7 @@ export const Header = () => {
   return (
     <nav className={navStyles({ isOpen })}>
       {isBannerVisible && (
-        <div className="relative flex items-center justify-center gap-2 w-full bg-gradient-to-r from-[#0194e2] to-[#7a3bff] text-white text-center text-sm px-6 py-2">
+        <div className="relative flex items-center justify-center gap-2 w-full bg-gradient-to-r from-[#1e1b4b] to-[#4c1d95] text-white text-center text-sm px-6 py-2">
           <span>
             ✨ New: Let your coding agent set up MLflow tracing for you:{" "}
             <code className="rounded bg-black/25 px-1.5 py-0.5 font-mono">

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -38,7 +38,7 @@ const GitHubStarsBadge = () => {
 };
 
 import "./Header.module.css";
-import { MLFLOW_DOCS_URL, MLFLOW_TRY_DEMO_URL } from "@site/src/constants";
+import { MLFLOW_TRY_DEMO_URL } from "@site/src/constants";
 import { cva } from "class-variance-authority";
 
 const MD_BREAKPOINT = 640;
@@ -174,7 +174,7 @@ export const Header = () => {
         </span>
         <CopyButton code="uvx mlflow agent setup" />
         <Link
-          href={MLFLOW_DOCS_URL}
+          href="https://mlflow.org/docs/latest/genai/tracing/quickstart/"
           className="underline font-medium text-white hover:text-white/80"
         >
           Learn more

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -8,7 +8,7 @@ import DownIcon from "@site/static/img/chevron-down-small.svg";
 import { cn, getStartedLinkForPage } from "../../utils";
 import { useGitHubStars } from "../../hooks/useGitHubStars";
 
-import { Star } from "lucide-react";
+import { Star, X } from "lucide-react";
 import { Button } from "../Button/Button";
 import { HeaderMenuItem } from "../HeaderMenuItem/HeaderMenuItem";
 import { HeaderProductsSubmenu } from "../HeaderProductsSubmenu/HeaderProductsSubmenu";
@@ -43,6 +43,8 @@ import { cva } from "class-variance-authority";
 
 const MD_BREAKPOINT = 640;
 
+const BANNER_DISMISSED_KEY = "mlflow-agent-setup-banner-dismissed";
+
 const navStyles = cva(
   "fixed w-full z-20 top-0 start-0 bg-black/20 border-b border-[#F7F8F8]/8 backdrop-blur-[20px] overflow-y-auto",
   {
@@ -57,6 +59,7 @@ const navStyles = cva(
 
 export const Header = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const [isBannerVisible, setIsBannerVisible] = useState(true);
   const [isProductItemHovered, setIsProductItemHovered] = useState(false);
   const [isProductSubmenuOpen, setIsProductSubmenuOpen] = useState(false);
   const [isDocsItemHovered, setIsDocsItemHovered] = useState(false);
@@ -142,6 +145,17 @@ export const Header = () => {
     }
   };
 
+  useEffect(() => {
+    if (localStorage.getItem(BANNER_DISMISSED_KEY) === "true") {
+      setIsBannerVisible(false);
+    }
+  }, []);
+
+  const dismissBanner = () => {
+    setIsBannerVisible(false);
+    localStorage.setItem(BANNER_DISMISSED_KEY, "true");
+  };
+
   useLayoutEffect(() => {
     const handleResize = () => {
       if (window.innerWidth >= MD_BREAKPOINT) {
@@ -165,21 +179,31 @@ export const Header = () => {
 
   return (
     <nav className={navStyles({ isOpen })}>
-      <div className="flex items-center justify-center gap-2 w-full bg-gradient-to-r from-[#0194e2] to-[#7a3bff] text-white text-center text-sm px-6 py-2">
-        <span>
-          ✨ New: Let your coding agent set up MLflow tracing for you:{" "}
-          <code className="rounded bg-black/25 px-1.5 py-0.5 font-mono">
-            uvx mlflow agent setup
-          </code>
-        </span>
-        <CopyButton code="uvx mlflow agent setup" />
-        <Link
-          href="https://mlflow.org/docs/latest/genai/tracing/quickstart/"
-          className="underline font-medium text-white hover:text-white/80"
-        >
-          Learn more
-        </Link>
-      </div>
+      {isBannerVisible && (
+        <div className="relative flex items-center justify-center gap-2 w-full bg-gradient-to-r from-[#0194e2] to-[#7a3bff] text-white text-center text-sm px-6 py-2">
+          <span>
+            ✨ New: Let your coding agent set up MLflow tracing for you:{" "}
+            <code className="rounded bg-black/25 px-1.5 py-0.5 font-mono">
+              uvx mlflow agent setup
+            </code>
+          </span>
+          <CopyButton code="uvx mlflow agent setup" />
+          <Link
+            href="https://mlflow.org/docs/latest/genai/tracing/quickstart/"
+            className="underline font-medium text-white hover:text-white/80"
+          >
+            Learn more
+          </Link>
+          <button
+            type="button"
+            onClick={dismissBanner}
+            aria-label="Dismiss banner"
+            className="absolute right-3 p-1 rounded text-white/70 hover:text-white hover:bg-white/10 transition-colors cursor-pointer"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      )}
       <div className="flex flex-wrap items-center mx-auto px-6 lg:px-20 py-2 max-w-container">
         <div className="md:contents flex flex-row justify-between w-full sticky top-[8px]">
           <Link

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -8,13 +8,12 @@ import DownIcon from "@site/static/img/chevron-down-small.svg";
 import { cn, getStartedLinkForPage } from "../../utils";
 import { useGitHubStars } from "../../hooks/useGitHubStars";
 
-import { Star, X } from "lucide-react";
+import { Star } from "lucide-react";
 import { Button } from "../Button/Button";
 import { HeaderMenuItem } from "../HeaderMenuItem/HeaderMenuItem";
 import { HeaderProductsSubmenu } from "../HeaderProductsSubmenu/HeaderProductsSubmenu";
 import { HeaderDocsSubmenu } from "../HeaderDocsSubmenu/HeaderDocsSubmenu";
 import { HeaderResourcesSubmenu } from "../HeaderResourcesSubmenu/HeaderResourcesSubmenu";
-import { CopyButton } from "../CodeSnippet/CopyButton";
 
 const GitHubStarsBadge = () => {
   const stars = useGitHubStars();
@@ -43,8 +42,6 @@ import { cva } from "class-variance-authority";
 
 const MD_BREAKPOINT = 640;
 
-const BANNER_DISMISSED_KEY = "mlflow-agent-setup-banner-dismissed";
-
 const navStyles = cva(
   "fixed w-full z-20 top-0 start-0 bg-black/20 border-b border-[#F7F8F8]/8 backdrop-blur-[20px] overflow-y-auto",
   {
@@ -59,7 +56,6 @@ const navStyles = cva(
 
 export const Header = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const [isBannerVisible, setIsBannerVisible] = useState(true);
   const [isProductItemHovered, setIsProductItemHovered] = useState(false);
   const [isProductSubmenuOpen, setIsProductSubmenuOpen] = useState(false);
   const [isDocsItemHovered, setIsDocsItemHovered] = useState(false);
@@ -145,17 +141,6 @@ export const Header = () => {
     }
   };
 
-  useEffect(() => {
-    if (localStorage.getItem(BANNER_DISMISSED_KEY) === "true") {
-      setIsBannerVisible(false);
-    }
-  }, []);
-
-  const dismissBanner = () => {
-    setIsBannerVisible(false);
-    localStorage.setItem(BANNER_DISMISSED_KEY, "true");
-  };
-
   useLayoutEffect(() => {
     const handleResize = () => {
       if (window.innerWidth >= MD_BREAKPOINT) {
@@ -179,34 +164,6 @@ export const Header = () => {
 
   return (
     <nav className={navStyles({ isOpen })}>
-      {/* Announcement banner for `mlflow agent setup`. Hidden on mobile
-          because the copy wraps poorly at narrow widths; dismissal is
-          remembered in localStorage. */}
-      {isBannerVisible && (
-        <div className="relative hidden md:flex items-center justify-center gap-2 w-full bg-gradient-to-r from-[#1e1b4b] to-[#4c1d95] text-white text-center text-sm px-6 py-2">
-          <span>
-            ✨ New: Let your coding agent set up MLflow tracing for you:{" "}
-            <code className="rounded bg-black/25 px-1.5 py-0.5 font-mono">
-              uvx mlflow@latest agent setup
-            </code>
-          </span>
-          <CopyButton code="uvx mlflow@latest agent setup" />
-          <Link
-            href="https://mlflow.org/docs/latest/genai/tracing/quickstart/"
-            className="underline font-medium text-white hover:text-white/80"
-          >
-            Learn more
-          </Link>
-          <button
-            type="button"
-            onClick={dismissBanner}
-            aria-label="Dismiss banner"
-            className="absolute right-3 p-1 rounded text-white/70 hover:text-white hover:bg-white/10 transition-colors cursor-pointer"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        </div>
-      )}
       <div className="flex flex-wrap items-center mx-auto px-6 lg:px-20 py-2 max-w-container">
         <div className="md:contents flex flex-row justify-between w-full sticky top-[8px]">
           <Link

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -184,10 +184,10 @@ export const Header = () => {
           <span>
             ✨ New: Let your coding agent set up MLflow tracing for you:{" "}
             <code className="rounded bg-black/25 px-1.5 py-0.5 font-mono">
-              uvx mlflow agent setup
+              uvx mlflow@latest agent setup
             </code>
           </span>
-          <CopyButton code="uvx mlflow agent setup" />
+          <CopyButton code="uvx mlflow@latest agent setup" />
           <Link
             href="https://mlflow.org/docs/latest/genai/tracing/quickstart/"
             className="underline font-medium text-white hover:text-white/80"

--- a/website/src/components/HeroSection/HeroSection.tsx
+++ b/website/src/components/HeroSection/HeroSection.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 import { motion } from "motion/react";
 import Link from "@docusaurus/Link";
 import { Button } from "../Button/Button";
+import { CopyButton } from "../CodeSnippet/CopyButton";
 
 type Props = {
   title: ReactNode;
@@ -15,6 +16,10 @@ type Props = {
     href: string;
     icon?: ReactNode;
   };
+  command?: {
+    code: string;
+    caption?: ReactNode;
+  };
   children?: ReactNode;
 };
 
@@ -23,6 +28,7 @@ export function HeroSection({
   subtitle,
   primaryCTA,
   secondaryCTA,
+  command,
   children,
 }: Props) {
   return (
@@ -71,6 +77,26 @@ export function HeroSection({
             </Link>
           )}
         </motion.div>
+
+        {/* Copyable command snippet */}
+        {command && (
+          <motion.div
+            className="flex flex-col items-center gap-2"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.25 }}
+          >
+            {command.caption && (
+              <span className="text-sm text-white/60">{command.caption}</span>
+            )}
+            <div className="flex items-center gap-3 rounded-xl border border-white/20 bg-black/40 pl-4 pr-2 py-2 font-mono text-sm text-white">
+              <span className="text-white/50 select-none">$</span>
+              <span>{command.code}</span>
+              <CopyButton code={command.code} />
+            </div>
+          </motion.div>
+        )}
+
         {children && (
           <motion.div
             initial={{ opacity: 0, y: 20 }}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -114,6 +114,12 @@ export default function Home(): JSX.Element {
             label: "Get Started",
             href: `#get-started`,
           }}
+          command={{
+            code: "uvx mlflow@latest agent setup",
+            caption: (
+              <>✨ New: let your coding agent set up MLflow tracing for you</>
+            ),
+          }}
         >
           <TrustPills />
         </HeroSection>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Advertise the new `mlflow agent setup` command with a copyable command snippet in the homepage hero, right below the CTA buttons. `HeroSection` gains an optional `command` prop (terminal-style chip reusing the existing `CopyButton`).

An earlier revision used a site-wide header banner, but per review feedback it was easy to miss and the banner slot is better reserved for temporary events (e.g. webinars). The hero placement is more prominent and also works on mobile, where the banner had to be hidden.

## Screenshots

**Homepage hero (desktop):**

<img src="https://github.com/user-attachments/assets/252d330d-6bc0-4e25-95a6-0ad4c564184d" alt="Homepage hero with copyable command" width="800" />

**Homepage hero (mobile):**

<img src="https://github.com/user-attachments/assets/1391abcb-7ff2-4156-8fd8-44417f34b7ea" alt="Mobile hero with copyable command" width="320" />

## Demo

**Copy the command from the hero:**

https://github.com/user-attachments/assets/aaec64c9-ac35-4390-aaf8-0628e02ae986

🤖 Generated with [Claude Code](https://claude.com/claude-code)