### PR TITLE
Increase e2e webServer timeout to 1 minute

### DIFF
--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -17,7 +17,7 @@ const config: PlaywrightTestConfig = {
     // Use production build to enable them.
     command: "npm run build && npm run serve",
     port: 3000,
-    timeout: 30 * 1000, // 30 seconds
+    timeout: 60 * 1000, // 1 minute
   },
 };
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

The e2e job intermittently fails with `Timed out waiting 30000ms from config.webServer` before any test runs (e.g. [this run](https://github.com/mlflow/mlflow-website/actions/runs/27265354604/job/80520987131), and recent article-sync PRs). The Playwright `webServer` hook runs a full production build (`npm run build && npm run serve`), which takes roughly 25-30 seconds in CI, so the 30-second timeout fires right at the boundary; in the linked failure the build finished about 3 seconds before the timeout, but `serve` had not yet bound the port.

Raising the timeout to 1 minute removes the race. This adds no time to passing runs, since Playwright proceeds as soon as the port is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)