### PR TITLE
Ignore `.playwright-cli/` artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ a.html
 a.py
 b.py
 c.py
+.playwright-cli/


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `.playwright-cli/` to `.gitignore`. The `playwright-cli` browser automation tool writes session artifacts (snapshots, screenshots, console logs, videos) to this directory, which should not be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)