### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
     name: Build Website
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.artifact.outputs.name }}
           path: website/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
       - working-directory: website

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set build identifier
         id: build-id
@@ -46,7 +46,7 @@ jobs:
           echo "value=$BUILD_ID" >> $GITHUB_OUTPUT
 
       - name: Download build artifacts
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           ARTIFACT_NAME: website-build-${{ steps.build-id.outputs.value }}
           EXTRACT_PATH: website/build
@@ -56,7 +56,7 @@ jobs:
             await downloadArtifact({ github, context });
 
       - name: Clean up GitHub artifacts
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           BUILD_ID: ${{ steps.build-id.outputs.value }}
         with:
@@ -91,7 +91,7 @@ jobs:
 
       - name: Comment PR with preview URL
         if: ${{ steps.build-id.outputs.is_main == 'false' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ steps.build-id.outputs.value }}
           NETLIFY_DOMAIN: ${{ secrets.NETLIFY_SITE_NAME }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,8 +10,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
       - working-directory: website

--- a/.github/workflows/fetch-articles.yml
+++ b/.github/workflows/fetch-articles.yml
@@ -13,7 +13,7 @@ jobs:
   fetch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
@@ -21,12 +21,12 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 

--- a/.github/workflows/format-release-note.yml
+++ b/.github/workflows/format-release-note.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.head.repo.full_name == 'mlflow/mlflow-website' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { data: commits } = await github.rest.pulls.listCommits({
@@ -41,9 +41,9 @@ jobs:
     outputs:
       reformatted: ${{ steps.patch.outputs.reformatted }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Format
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -66,7 +66,7 @@ jobs:
           echo "reformatted=$reformatted" >> $GITHUB_OUTPUT
 
       - name: Upload patch
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.run_id }}.diff
           path: ${{ github.run_id }}.diff
@@ -76,7 +76,7 @@ jobs:
     needs: [check-maintainer, format]
     if: ${{ needs.format.outputs.reformatted == 'true' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 300
           repository: ${{ github.event.pull_request.base.repo.full_name }}
@@ -84,7 +84,7 @@ jobs:
           token: ${{ secrets.MLFLOW_AUTOMATION_TOKEN }}
 
       - name: Download patch
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.run_id }}.diff
           path: /tmp

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -21,7 +21,7 @@ jobs:
       issues: write # harupy/auto-labeling
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
       - uses: harupy/auto-labeling@937d558e37285af6ca5c5813a826cf6f0d66bf0f # master

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -16,8 +16,8 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
       - name: Install dependencies

--- a/.github/workflows/team-review.yml
+++ b/.github/workflows/team-review.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;


### PR DESCRIPTION
## Summary

Bumps all `actions/*` workflows to their latest releases, pinned by full commit SHA with `vX.Y.Z` comments (previously `# v4` / `# v3`, which don't say which patch is pinned).

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 (v3 in `e2e.yml`) | v7.0.1 |
| `actions/setup-node` | v4 (v3 in `e2e.yml`) | v7.0.0 |
| `actions/upload-artifact` | v4 | v7.0.1 |
| `actions/download-artifact` | v4 | v8.0.1 |
| `actions/github-script` | v7 / v7.0.1 | v9.0.0 |
| `actions/create-github-app-token` | v3.1.1 | v3.2.0 |

`harupy/auto-labeling` is left alone: its newest tag (v0.0.2) is 89 commits behind the pinned SHA, which is current `master`.

## Breaking changes checked against our usage (none apply)

- **checkout v7** blocks fork-PR checkout under `pull_request_target` / `workflow_run`. `deploy.yml` runs on `workflow_run` but does a default self-checkout (no `ref`), which the guard skips; `format-release-note.yml`'s custom `repository`/`ref` checkout runs on `pull_request`, which the guard doesn't cover.
- **github-script v9** is ESM: `require('@actions/github')` fails and `getOctokit` is now an injected parameter. Our scripts only `require()` local CJS files, and none redeclare `getOctokit`.
- **setup-node v5+** auto-enables npm caching from a root `package.json`. There is none at the repo root (it's under `website/`), so behavior is unchanged.
- **download-artifact v8** errors on digest mismatch instead of warning — paired with upload-artifact v7 in the same workflow.
- **Node 24 runtimes** require runner >= 2.327.1, which `ubuntu-latest` satisfies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)