### PR TITLE
Add env_pack ARM bug fix to 3.15.1 release notes

### DIFF
--- a/website/releases/2026-08-02-3.15.1-release.mdx
+++ b/website/releases/2026-08-02-3.15.1-release.mdx
@@ -5,10 +5,11 @@ slug: 3.15.1
 authors: [mlflow-maintainers]
 ---
 
-MLflow 3.15.1 is a patch release that includes a bug fix and documentation updates.
+MLflow 3.15.1 is a patch release that includes bug fixes and documentation updates.
 
 Bug fixes:
 
+- [Model Registry] Skip `env_pack` on ARM client images ([#24762](https://github.com/mlflow/mlflow/pull/24762), [@qyc](https://github.com/qyc))
 - [Scoring / Tracking] Harden version parsing against missing/non-PEP440 versions on Databricks Serverless ([#24799](https://github.com/mlflow/mlflow/pull/24799), [@PattaraS](https://github.com/PattaraS))
 
 Documentation updates:


### PR DESCRIPTION
Adds the `env_pack` ARM client-image bug fix ([#24762](https://github.com/mlflow/mlflow/pull/24762), backported to `branch-3.15` via [#24835](https://github.com/mlflow/mlflow/pull/24835)) to the 3.15.1 release notes.

Follow-up to the 3.15.1 release post (#670).

Note: #24835 (the backport into `branch-3.15`) should be merged before the 3.15.1 release is cut.