### PR TITLE
Fix header spacing between Resources and GitHub stars

### DIFF
--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -15,14 +15,20 @@ import { HeaderProductsSubmenu } from "../HeaderProductsSubmenu/HeaderProductsSu
 import { HeaderDocsSubmenu } from "../HeaderDocsSubmenu/HeaderDocsSubmenu";
 import { HeaderResourcesSubmenu } from "../HeaderResourcesSubmenu/HeaderResourcesSubmenu";
 
-const GitHubStarsBadge = () => {
+const GitHubStarsBadge = ({ className }: { className?: string }) => {
   const stars = useGitHubStars();
   return (
     <a
       href="https://github.com/mlflow/mlflow"
       target="_blank"
       rel="noreferrer noopener"
-      className="hidden md:flex items-center gap-1.5 rounded-xl bg-white/10 border border-white/20 px-4 py-2 text-[15px] text-white hover:bg-white/15 hover:border-white/30 transition-all"
+      aria-label={
+        stars ? `MLflow on GitHub, ${stars} stars` : "MLflow on GitHub"
+      }
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-xl bg-white/10 border border-white/20 px-3 py-2 text-[14px] text-white hover:bg-white/15 hover:border-white/30 transition-all",
+        className,
+      )}
     >
       <svg viewBox="0 0 48 48" fill="none" className="w-4 h-4">
         <path
@@ -41,7 +47,7 @@ import { MLFLOW_TRY_DEMO_URL } from "@site/src/constants";
 import { reportTryDemo } from "@site/src/utils/siteEvents";
 import { cva } from "class-variance-authority";
 
-const MD_BREAKPOINT = 640;
+const XL_BREAKPOINT = 1280;
 
 const navStyles = cva(
   "fixed w-full z-20 top-0 start-0 bg-black/20 border-b border-[#F7F8F8]/8 backdrop-blur-[20px] overflow-y-auto",
@@ -144,7 +150,7 @@ export const Header = () => {
 
   useLayoutEffect(() => {
     const handleResize = () => {
-      if (window.innerWidth >= MD_BREAKPOINT) {
+      if (window.innerWidth >= XL_BREAKPOINT) {
         setIsOpen(false);
       }
     };
@@ -165,25 +171,25 @@ export const Header = () => {
 
   return (
     <nav className={navStyles({ isOpen })}>
-      <div className="flex flex-wrap items-center mx-auto px-6 lg:px-20 py-2 max-w-container">
-        <div className="md:contents flex flex-row justify-between w-full sticky top-[8px]">
+      <div className="flex flex-wrap items-center justify-between gap-x-6 mx-auto px-6 py-2 max-w-container xl:grid xl:grid-cols-[auto_minmax(0,1fr)_auto] xl:items-center xl:gap-x-12 xl:px-20">
+        <div className="flex flex-row justify-between w-full sticky top-[8px] xl:contents">
           <Link
             href="/"
-            className="flex items-center space-x-3 rtl:space-x-reverse grow basis-0"
+            className="flex items-center space-x-3 rtl:space-x-reverse xl:justify-self-start"
             aria-label="MLflow Home"
           >
             <Logo className="h-[36px]" aria-hidden="true" />
           </Link>
-          <div className="flex flex-row items-center gap-3 md:order-2 md:gap-4 rtl:space-x-reverse grow justify-end basis-0">
-            <GitHubStarsBadge />
-            <Link href={getStartedHref} className="hidden md:block">
+          <div className="flex flex-row items-center gap-2 xl:order-last xl:w-full xl:justify-end xl:justify-self-end rtl:space-x-reverse">
+            <GitHubStarsBadge className="hidden xl:inline-flex" />
+            <Link href={getStartedHref} className="hidden xl:block">
               <Button variant="outline" size="small">
                 Get Started
               </Button>
             </Link>
             <Link
               href={MLFLOW_TRY_DEMO_URL}
-              className="hidden md:block"
+              className="hidden xl:block"
               onClick={reportTryDemo}
             >
               <Button variant="primary" size="small">
@@ -193,7 +199,7 @@ export const Header = () => {
             <button
               data-collapse-toggle="navbar-sticky"
               type="button"
-              className="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-white md:hidden focus:outline-none cursor-pointer"
+              className="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-white xl:hidden focus:outline-none cursor-pointer"
               onClick={() => setIsOpen(!isOpen)}
             >
               <span className="sr-only">Open main menu</span>
@@ -217,12 +223,12 @@ export const Header = () => {
         </div>
         <div
           className={cn(
-            "items-center justify-between w-full md:flex md:w-auto md:order-1 mt-4 md:mt-0",
-            isOpen ? "flex" : "hidden md:flex",
+            "items-center justify-between w-full xl:flex xl:w-auto xl:justify-self-center mt-4 xl:mt-0",
+            isOpen ? "flex" : "hidden xl:flex",
           )}
         >
-          <ul className="flex flex-col font-medium md:flex-row gap-y-6 gap-x-4 lg:gap-x-10 w-full md:w-auto">
-            <li className="w-full md:w-auto md:hidden">
+          <ul className="flex flex-col font-medium xl:flex-row gap-y-6 xl:gap-x-8 w-full xl:w-auto">
+            <li className="w-full xl:w-auto xl:hidden">
               <button
                 type="button"
                 onClick={handleProductItemClick}
@@ -251,19 +257,19 @@ export const Header = () => {
               </div>
             </li>
             <li
-              className="w-full md:w-auto hidden md:block"
+              className="w-full xl:w-auto hidden xl:block"
               onMouseEnter={handleProductItemHover}
               onClick={toggleProductSubmenuHovered}
             >
               <HeaderMenuItem label="Components" hasDropdown />
             </li>
-            <li className="w-full md:w-auto">
+            <li className="w-full xl:w-auto">
               <HeaderMenuItem href="/releases" label="Releases" />
             </li>
-            <li className="w-full md:w-auto">
+            <li className="w-full xl:w-auto">
               <HeaderMenuItem href="/blog" label="Blog" />
             </li>
-            <li className="w-full md:w-auto md:hidden">
+            <li className="w-full xl:w-auto xl:hidden">
               <button
                 type="button"
                 onClick={handleDocsItemClick}
@@ -292,13 +298,13 @@ export const Header = () => {
               </div>
             </li>
             <li
-              className="w-full md:w-auto hidden md:block"
+              className="w-full xl:w-auto hidden xl:block"
               onMouseEnter={handleDocsItemHover}
               onClick={toggleDocsSubmenuHovered}
             >
               <HeaderMenuItem label="Docs" hasDropdown />
             </li>
-            <li className="w-full md:w-auto md:hidden">
+            <li className="w-full xl:w-auto xl:hidden">
               <button
                 type="button"
                 onClick={handleResourcesItemClick}
@@ -327,13 +333,14 @@ export const Header = () => {
               </div>
             </li>
             <li
-              className="w-full md:w-auto hidden md:block"
+              className="w-full xl:w-auto hidden xl:block"
               onMouseEnter={handleResourcesItemHover}
               onClick={toggleResourcesSubmenuHovered}
             >
               <HeaderMenuItem label="Resources" hasDropdown />
             </li>
-            <li className="w-full md:w-auto md:hidden flex flex-col gap-2">
+            <li className="w-full xl:w-auto xl:hidden flex flex-col gap-2 mt-4">
+              <GitHubStarsBadge className="w-full justify-center" />
               <Link href={getStartedHref}>
                 <Button variant="outline" size="small" width="full">
                   Get Started

--- a/website/src/components/HeaderMenuItem/HeaderMenuItem.tsx
+++ b/website/src/components/HeaderMenuItem/HeaderMenuItem.tsx
@@ -21,14 +21,14 @@ export const HeaderMenuItem = ({
     <Link
       href={href}
       className={cn(
-        "flex items-center gap-2 py-2 text-white text-lg w-full md:w-auto cursor-pointer transition-colors duration-200 hover:!text-white/60",
+        "flex items-center gap-1.5 py-2 text-white text-lg w-full xl:w-auto cursor-pointer transition-colors duration-200 hover:!text-white/60",
         className,
       )}
       {...props}
     >
       {label}
 
-      {hasDropdown && <DownIcon className="w-6 h-6" />}
+      {hasDropdown && <DownIcon className="w-4 h-4" />}
     </Link>
   );
 };


### PR DESCRIPTION
## Why this looked off

The header is three groups: brand, destination nav, and actions (GitHub stars, Get Started, Try Demo). Those groups were not spaced that way.

The logo and the action cluster both used `grow` with equal flex basis, and the parent row had no gap. The action cluster is much wider than the logo, so leftover space collected after the logo. Resources and the stars badge ended up closer together than Docs and Resources. The badge read as another nav item instead of part of the CTA group.

That is a proximity problem. Things that sit close together get read as related, even when they are not. [NN/g on Gestalt proximity](https://www.nngroup.com/articles/gestalt-proximity/) is the same pattern: extra space between the main nav and utility actions is what tells you they do different jobs. Equal spacing everywhere flattens that.

It also broke on mid widths. At 768 and 1024 the bar wrapped into two uneven rows, with Resources still jammed against the badge.

## What changed

- Desktop (1280+) uses a three-column grid: logo | nav | actions. The grid gap is the floor between groups. Nav items sit 32px apart. Actions sit 8px apart. The space between Resources and GitHub is larger than the space inside either group (about 72px at 1280, 152px at 1440).
- Dropdown chevrons are sized to the text so they stop eating the gap after Resources.
- Below 1280 the full bar cannot keep those groups apart, so it becomes a hamburger. GitHub stars move into the drawer with the CTAs, with extra space above that cluster so they do not blur into Resources.

## Screenshots

### Desktop, 1440

The Resources-to-stars gap is the one that felt wrong.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/anxkhn/mlflow-website/pr-assets/header-nav-action-spacing/pr-assets/before-desktop-cluster.png" alt="Before: Resources sitting against the GitHub stars badge on desktop" width="720" /> | <img src="https://raw.githubusercontent.com/anxkhn/mlflow-website/pr-assets/header-nav-action-spacing/pr-assets/after-desktop-cluster.png" alt="After: Resources separated from the GitHub stars and CTA cluster on desktop" width="720" /> |

Full bar:

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/anxkhn/mlflow-website/pr-assets/header-nav-action-spacing/pr-assets/before-desktop.png" alt="Before: full desktop header at 1440px" width="720" /> | <img src="https://raw.githubusercontent.com/anxkhn/mlflow-website/pr-assets/header-nav-action-spacing/pr-assets/after-desktop.png" alt="After: full desktop header at 1440px" width="720" /> |

### Laptop, 1280

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/anxkhn/mlflow-website/pr-assets/header-nav-action-spacing/pr-assets/before-laptop.png" alt="Before: header at 1280px with uneven nav gaps and a tight Resources-to-stars join" width="720" /> | <img src="https://raw.githubusercontent.com/anxkhn/mlflow-website/pr-assets/header-nav-action-spacing/pr-assets/after-laptop.png" alt="After: header at 1280px with even nav rhythm and a clear action group" width="720" /> |

### Tablet, 1024

The old bar wrapped. The new one uses the drawer so the groups stay intact.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/anxkhn/mlflow-website/pr-assets/header-nav-action-spacing/pr-assets/before-tablet.png" alt="Before: wrapped two-row header at 1024px" width="720" /> | <img src="https://raw.githubusercontent.com/anxkhn/mlflow-website/pr-assets/header-nav-action-spacing/pr-assets/after-tablet.png" alt="After: single-row header with hamburger at 1024px" width="720" /> |

<img src="https://raw.githubusercontent.com/anxkhn/mlflow-website/pr-assets/header-nav-action-spacing/pr-assets/after-tablet-menu.png" alt="After: tablet drawer with GitHub stars grouped with the CTAs" width="720" />

### Mobile, 390

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/anxkhn/mlflow-website/pr-assets/header-nav-action-spacing/pr-assets/before-mobile.png" alt="Before: mobile header" width="240" /> | <img src="https://raw.githubusercontent.com/anxkhn/mlflow-website/pr-assets/header-nav-action-spacing/pr-assets/after-mobile.png" alt="After: mobile header" width="240" /> |

<img src="https://raw.githubusercontent.com/anxkhn/mlflow-website/pr-assets/header-nav-action-spacing/pr-assets/after-mobile-menu.png" alt="After: mobile drawer with GitHub stars grouped above Get Started and Try Demo" width="240" />