### PR TITLE
Serve the MLflow skills installer at mlflow.org/skills/install.sh

### DIFF
--- a/website/static/skills/install.sh
+++ b/website/static/skills/install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Convenience entrypoint served at https://mlflow.org/skills/install.sh
+# Fetches and runs the canonical MLflow Skills installer from
+# https://github.com/mlflow/skills (single source of truth; see that repo for
+# the script source, options, and issues).
+set -eu
+curl -fsSL https://raw.githubusercontent.com/mlflow/skills/main/install.sh | sh -s -- "$@"


### PR DESCRIPTION
## What

Serves the MLflow skills installer at a clean, memorable URL:

```bash
curl -fsSL https://mlflow.org/skills/install.sh | sh
```

Adds `website/static/skills/install.sh`, which Docusaurus publishes verbatim at the site root (`/skills/install.sh`).

## Why

Companion to mlflow/skills#38, which adds the installer. A short `mlflow.org` URL is friendlier for docs, onboarding, and agent setup flows than the raw `githubusercontent.com` link.

## How

The file is a tiny entrypoint that fetches and runs the canonical installer from `github.com/mlflow/skills` (single source of truth), forwarding any arguments — so the installer logic lives in one repo, not two.

> **Depends on mlflow/skills#38.** The entrypoint fetches `raw.githubusercontent.com/mlflow/skills/main/install.sh`, which exists once that PR merges. Safe to hold this PR until then.

This pull request and its description were written by Isaac.