### PR TITLE
Publish canonical setup wizard at `/wizard/setup.sh`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,22 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Checkout MLflow setup wizard
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: mlflow/mlflow
+          ref: master
+          sparse-checkout: mlflow/agent/setup/setup.sh
+          sparse-checkout-cone-mode: false
+          path: mlflow-source
+          persist-credentials: false
+
+      - name: Stage MLflow setup wizard
+        run: |
+          mkdir -p website/static/wizard
+          cp mlflow-source/mlflow/agent/setup/setup.sh website/static/wizard/setup.sh
+          sh -n website/static/wizard/setup.sh
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
@@ -36,6 +52,9 @@ jobs:
         env:
           GTM_ID: ${{ secrets.GTM_ID }}
         run: npm run build
+
+      - name: Verify MLflow setup wizard
+        run: cmp website/static/wizard/setup.sh website/build/wizard/setup.sh
 
       - name: Set artifact name
         id: artifact


### PR DESCRIPTION
## What changed

Update the website build to fetch `mlflow/agent/setup/setup.sh` from `mlflow/mlflow@master` with a sparse checkout and publish it as `/wizard/setup.sh`.

The build syntax-checks the shell script before running Docusaurus and verifies that the generated artifact is byte-identical before upload.

## Why

This provides a first-party `https://mlflow.org/wizard/setup.sh` installation URL while keeping `mlflow/mlflow` as the single source of truth. The website does not need to maintain a duplicate copy; each website deployment incorporates the current canonical script.

## Testing

Verified through preview link: https://pr-708--test-mlflow-website.netlify.app/wizard/setup.sh