### PR TITLE
Add MCP Server and MCP Registry cookbooks

### DIFF
--- a/website/cookbook/2026-09-05-mlflow-mcp-registry/index.md
+++ b/website/cookbook/2026-09-05-mlflow-mcp-registry/index.md
@@ -1,0 +1,364 @@
+---
+title: "How to Register, Version, and Discover MCP Servers with the MLflow MCP Registry"
+slug: mlflow-mcp-registry
+description: "Register custom and third-party MCP servers in a governed catalog with live tool auto-discovery, versions, aliases, and access endpoints."
+tags: [mcp, registry, governance, tools]
+date: 2026-09-05T11:00:00
+---
+
+Register a custom MCP server and a public third-party one in a single governed catalog, let MLflow auto-discover their tools, then manage versions, aliases, and access endpoints -- and call a discovered tool straight from the endpoint the registry recorded.
+
+<!-- truncate -->
+
+![The MLflow MCP Registry catalogs MCP servers as three entities -- MCPServer, MCPServerVersion (with a tool snapshot), and MCPAccessEndpoint -- registering, versioning, and auto-discovering the tools of both custom and external servers.](./mlflow_mcp_registry.svg)
+
+As teams adopt the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), they end up with many servers -- some they build, many third-party. The **MLflow MCP Registry** (new in MLflow 3.15) is a catalog, backed by your MLflow tracking server, for registering those servers, versioning them, snapshotting their tool definitions via auto-discovery, aliasing versions (e.g. `production`), and recording access endpoints. It answers, in one place: which MCP servers exist, what tools do they offer, and where do I reach them?
+
+The registry has three entities, each with its own identity and lifecycle:
+
+| Entity              | What it is                                                                                        |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| `MCPServer`         | The logical server, identified by a namespaced name like `io.github.org/slug`.                    |
+| `MCPServerVersion`  | A semver'd version holding the `server.json`, a snapshot of the server's tools, and a status.     |
+| `MCPAccessEndpoint` | A concrete URL + transport clients use to reach a running instance, pinned to a version or alias. |
+
+A version moves through a status lifecycle: **`draft → active → deprecated → deleted`**.
+
+:::tip[Prerequisites]
+
+```bash
+pip install "mlflow[mcp]>=3.15"
+```
+
+Start a tracking server on the MLflow 3.15 schema and leave it running -- the registry lives in the tracking store:
+
+```bash
+mlflow server --backend-store-uri sqlite:///mlflow.db --port 5000
+```
+
+:::
+
+## What You'll Build
+
+Point MLflow at your running server and confirm the version supports the registry. No experiment is needed -- registry entities live in the tracking store itself, not inside an experiment.
+
+```python
+import os
+import sys
+import mlflow
+from packaging.version import Version
+
+TRACKING_URI = "http://localhost:5000"
+os.environ["MLFLOW_TRACKING_URI"] = TRACKING_URI
+mlflow.set_tracking_uri(TRACKING_URI)
+
+assert Version(mlflow.__version__) >= Version("3.15"), (
+    f"The MCP Registry needs MLflow >= 3.15 (found {mlflow.__version__})."
+)
+print(f"MLflow {mlflow.__version__} -> {TRACKING_URI}")
+# Example: MLflow 3.15.1 -> http://localhost:5000
+```
+
+### Add a Cleanup Helper to Keep the Recipe Re-Runnable
+
+A server can't be deleted while it has an **active** version, and a version can't jump straight from `active` to `deleted`. To keep this recipe safely re-runnable, define a helper that deprecates each version, deletes it, then deletes the server.
+
+```python
+import asyncio
+import nest_asyncio  # only needed to call asyncio.run() inside a notebook/REPL loop
+
+from mlflow.genai import (
+    register_mcp_server,
+    get_mcp_server,
+    get_mcp_server_version_by_alias,
+    set_mcp_server_alias,
+    set_mcp_server_tag,
+    search_mcp_servers,
+    search_mcp_server_versions,
+    search_mcp_access_endpoints,
+    update_mcp_server_version,
+    delete_mcp_server_version,
+    delete_mcp_server,
+    refresh_mcp_server_version_tools,
+)
+
+nest_asyncio.apply()
+
+
+def deregister_mcp_server(name: str) -> None:
+    """Fully remove a server so the recipe is re-runnable. Every step is best-effort."""
+    try:
+        get_mcp_server(name)  # raises if the server doesn't exist yet
+    except Exception:
+        return
+    for v in search_mcp_server_versions(name):
+        try:
+            update_mcp_server_version(name, v.version, status="deprecated")
+        except Exception:
+            pass
+        try:
+            delete_mcp_server_version(name, v.version)
+        except Exception:
+            pass
+    try:
+        delete_mcp_server(name)
+    except Exception:
+        pass
+```
+
+### Register a Custom MCP Server with Live Tool Auto-Discovery
+
+The registry catalogs any MCP server via its `server.json` (name, version, and one or more `remotes`). When you register with `tools` left unset, MLflow performs **live auto-discovery**: it connects to the first `remotes[]` URL and snapshots the server's tool list into the `MCPServerVersion`.
+
+To make discovery real, first stand up a custom server -- an **orders-analytics** tool, a common reason teams build a custom MCP server: letting an assistant query their data. It wraps a small in-memory SQLite orders table and exposes `run_sql(query)` and `top_products(limit)`. The server lives in `utils/orders_analytics_mcp.py`; here we launch it as a subprocess and wait for its port.
+
+```python
+import subprocess
+import socket
+import time
+from pathlib import Path
+
+# Must match HOST / PORT in utils/orders_analytics_mcp.py.
+CUSTOM_HOST, CUSTOM_PORT = "127.0.0.1", 8123
+CUSTOM_URL = f"http://{CUSTOM_HOST}:{CUSTOM_PORT}/mcp"
+
+custom_proc = subprocess.Popen(
+    [sys.executable, str(Path("utils/orders_analytics_mcp.py"))],
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+
+
+def wait_for_port(host, port, timeout=15):
+    """Wait for a port to accept connections on a host."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with socket.socket() as s:
+            s.settimeout(1)
+            if s.connect_ex((host, port)) == 0:
+                return True
+        time.sleep(0.3)
+    return False
+
+
+assert wait_for_port(CUSTOM_HOST, CUSTOM_PORT), "custom MCP server did not start"
+print(f"Custom MCP server listening at {CUSTOM_URL} (pid={custom_proc.pid})")
+```
+
+Register it. With `tools` left unset, MLflow auto-discovers them from `remotes[0]` at registration time, and `create_access_endpoints_from_remotes=True` records an access endpoint per remote so consumers can find it later. Reverse-DNS names are recommended for MCP servers.
+
+```python
+CUSTOM_NAME = "io.github.example/orders-analytics"
+
+# Idempotent: remove any prior run's registration so this re-runs cleanly.
+deregister_mcp_server(CUSTOM_NAME)
+
+custom_server_json = {
+    "name": CUSTOM_NAME,
+    "version": "1.0.0",
+    "description": "Orders analytics MCP server: query an orders table via SQL.",
+    "remotes": [{"url": CUSTOM_URL, "type": "streamable-http"}],
+}
+
+custom_version = register_mcp_server(
+    server_json=custom_server_json,
+    status="active",
+    create_access_endpoints_from_remotes=True,
+)
+print(f"Registered '{custom_version.name}' v{custom_version.version} "
+      f"(status={custom_version.status})")
+print(f"Auto-discovered tools: {[t.name for t in (custom_version.tools or [])]}")
+# Example: Registered 'io.github.example/orders-analytics' v1.0.0 (status=active)
+# Example: Auto-discovered tools: ['run_sql', 'top_products']
+
+# Give the active version a friendly alias and a tag for governance.
+set_mcp_server_alias(CUSTOM_NAME, "staging", custom_version.version)
+set_mcp_server_tag(CUSTOM_NAME, "team", "mcp-genai-tutorials")
+
+server = get_mcp_server(CUSTOM_NAME)
+print(f"Alias 'staging' -> v{server.aliases.get('staging')}  |  Tags: {server.tags}")
+# Example: Alias 'staging' -> v1.0.0  |  Tags: {'team': 'mcp-genai-tutorials'}
+```
+
+### From Registry Entry to a Live Tool Call (register → discover → use)
+
+Registration recorded an access endpoint. A consumer can look that endpoint up in the registry and connect straight to it -- closing the loop from _register_ → _discover_ → _use_. Resolve the endpoint and call the `top_products` tool we discovered.
+
+```python
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+endpoint = search_mcp_access_endpoints(server_name=CUSTOM_NAME)[0]
+print(f"Access endpoint: {endpoint.url} ({endpoint.transport_type})")
+
+
+async def query_orders():
+    async with Client(StreamableHttpTransport(endpoint.url)) as client:
+        top = await client.call_tool("top_products", {"limit": 3})
+        for row in top.data:
+            print(f"  {row['product']:<28} ${row['revenue']:>8,.2f}  ({row['units']} units)")
+
+
+asyncio.run(query_orders())
+# Example:
+# Access endpoint: http://127.0.0.1:8123/mcp (streamable-http)
+#   Aurora Standing Desk         $1,920.00  (4 units)
+#   Volt 27in Monitor            $1,860.00  (6 units)
+#   Nimbus Office Chair          $1,100.00  (5 units)
+```
+
+### Register a Third-Party MCP Server (DeepWiki) by URL
+
+Registering a third-party server is the same call -- you just point `remotes[]` at _their_ endpoint. Register **DeepWiki**, a public MCP server (no auth) that answers questions about GitHub repositories; live discovery snapshots its real tools. Custom MCP serves structured data, DeepWiki serves unstructured docs -- the kind of mixed fleet a registry is meant to catalog.
+
+```python
+DEEPWIKI_NAME = "com.deepwiki/mcp"
+deregister_mcp_server(DEEPWIKI_NAME)
+
+deepwiki_server_json = {
+    "name": DEEPWIKI_NAME,
+    "version": "1.0.0",
+    "description": "DeepWiki public MCP server -- ask questions about GitHub repositories.",
+    "remotes": [{"url": "https://mcp.deepwiki.com/mcp", "type": "streamable-http"}],
+}
+
+try:
+    deepwiki_version = register_mcp_server(
+        server_json=deepwiki_server_json,
+        status="active",
+        create_access_endpoints_from_remotes=True,
+    )
+    print(f"Registered '{deepwiki_version.name}' v{deepwiki_version.version}")
+    print(f"Auto-discovered tools: {[t.name for t in (deepwiki_version.tools or [])]}")
+    # Example: Auto-discovered tools: ['ask_question', 'read_wiki_contents', 'read_wiki_structure']
+except Exception as e:
+    print(f"Live discovery failed ({type(e).__name__}: {e}).")
+    print("Register with an explicit `tools=[...]` list instead when a remote is offline or authed.")
+```
+
+### Call a Registered Server's Tools Programmatically or from an Assistant
+
+There are two ways to use a registered server's tools -- the same two as for the MLflow MCP Server: call it programmatically, or wire it into your assistant.
+
+**Programmatically** -- resolve the endpoint the registry recorded for DeepWiki, connect, and call its `ask_question` tool. This is a live call to a remote LLM-backed service, so it takes a few seconds; it's wrapped so a network hiccup won't break the run.
+
+```python
+deepwiki_endpoint = search_mcp_access_endpoints(server_name=DEEPWIKI_NAME)[0]
+
+
+async def ask_deepwiki(repo: str, question: str) -> str:
+    async with Client(StreamableHttpTransport(deepwiki_endpoint.url)) as client:
+        result = await client.call_tool("ask_question", {"repoName": repo, "question": question})
+        return result.content[0].text if result.content else str(result.data)
+
+
+try:
+    answer = asyncio.run(ask_deepwiki(
+        "modelcontextprotocol/python-sdk",
+        "What transport types does the MCP server support?",
+    ))
+    print(answer[:400])
+    # Example: The MCP server supports three primary transport types: `stdio`,
+    # `sse`, and `streamable-http`. ...
+except Exception as e:
+    print(f"(DeepWiki call failed -- the remote may be slow/unavailable: {type(e).__name__}: {e})")
+```
+
+**From your assistant** -- register the server once and its tools become available. DeepWiki is a remote HTTP MCP server, so (unlike the MLflow stdio server) you register it **by URL** -- no subprocess, no `command`.
+
+```bash
+# Claude Code / Claude Desktop
+claude mcp add --transport http deepwiki https://mcp.deepwiki.com/mcp
+```
+
+```json
+// Claude project-level .mcp.json (VS Code uses the same shape under a "servers" key)
+{
+  "mcpServers": {
+    "deepwiki": { "type": "http", "url": "https://mcp.deepwiki.com/mcp" }
+  }
+}
+```
+
+Then just ask in natural language, and the assistant calls `ask_question` for you:
+
+- _"Using DeepWiki, what transport types does the modelcontextprotocol/python-sdk server support?"_
+- _"Ask DeepWiki how authentication works in the openai/openai-python repo."_
+
+### Version Servers and Promote with the `production` Alias
+
+A registry's value shows up when servers change. Register a new version of the custom server, then point the `production` alias to it -- consumers that resolve `production` follow along without changing their config.
+
+```python
+# Register v1.1.0 of the same server (same remote -> same tools re-discovered).
+v11 = register_mcp_server(
+    server_json={**custom_server_json, "version": "1.1.0"},
+    status="active",
+)
+
+# Promote it: point the 'production' alias at 1.1.0.
+set_mcp_server_alias(CUSTOM_NAME, "production", "1.1.0")
+promoted = get_mcp_server_version_by_alias(CUSTOM_NAME, "production").version
+print(f"Alias 'production' now -> v{promoted}")
+# Example: Alias 'production' now -> v1.1.0
+```
+
+Browse the catalog -- servers, a server's versions with their tool snapshots, and access endpoints -- and do a dry-run tool refresh that shows what _would_ be snapshotted without saving.
+
+```python
+print("Registered MCP servers:")
+for s in search_mcp_servers():
+    print(f"  - {s.name} (status={s.status}, latest=v{s.latest_version})")
+
+print(f"\nVersions of {CUSTOM_NAME}:")
+for v in search_mcp_server_versions(CUSTOM_NAME):
+    print(f"  - v{v.version}  status={v.status}  tools={[t.name for t in (v.tools or [])]}")
+
+print(f"\nAccess endpoints for {CUSTOM_NAME}:")
+for ep in search_mcp_access_endpoints(server_name=CUSTOM_NAME):
+    print(f"  - {ep.url} ({ep.transport_type})")
+
+refreshed = refresh_mcp_server_version_tools(CUSTOM_NAME, "1.1.0", dry_run=True)
+print(f"\nrefresh v1.1.0 (dry_run) would snapshot: {[t.name for t in (refreshed.tools or [])]}")
+# Example:
+# Registered MCP servers:
+#   - com.deepwiki/mcp (status=active, latest=v1.0.0)
+#   - io.github.example/orders-analytics (status=active, latest=v1.1.0)
+# Versions of io.github.example/orders-analytics:
+#   - v1.0.0  status=active  tools=['run_sql', 'top_products']
+#   - v1.1.0  status=active  tools=['run_sql', 'top_products']
+```
+
+Open the tracking server at **http://localhost:5000** and select the **MCP Registry** section in the sidebar to browse both servers in the UI -- drill into a version to inspect its `server.json` and tool snapshot, and view its aliases and access endpoints.
+
+### Remove Registry Entries and Stop the Server
+
+Remove the demo registrations and stop the local custom server.
+
+```python
+for name in [CUSTOM_NAME, DEEPWIKI_NAME]:
+    deregister_mcp_server(name)  # deprecate -> delete versions -> delete server
+    print(f"Removed registry entry: {name}")
+
+try:
+    custom_proc.terminate()
+    custom_proc.wait(timeout=5)
+    print(f"Stopped custom MCP server (pid={custom_proc.pid})")
+except Exception as e:
+    print(f"(custom server already stopped: {e})")
+```
+
+## Results
+
+After completing this cookbook, you have:
+
+1. **A custom server in the catalog** -- registered orders-analytics with live tool auto-discovery, an alias, and a governance tag, then resolved its access endpoint and called a discovered tool (register → discover → use).
+2. **A third-party server, same call** -- registered DeepWiki by pointing `remotes[]` at its endpoint, then queried it through the recorded endpoint with `ask_question`, with a fallback for offline or authenticated remotes.
+3. **Versions and aliases** -- added v1.1.0 and re-pointed the `production` alias so consumers follow along without config changes.
+4. **A browsable inventory** -- listed servers, versions with tool snapshots, and access endpoints from code and in the MLflow UI, plus a dry-run tool refresh.
+
+## Next Steps
+
+- [MLflow MCP Server: Debug, Analyze, and Annotate Traces from Any AI Assistant](/cookbook/mlflow-mcp-server) -- Point an AI assistant at MLflow's built-in MCP tools to observe and act on your traces.
+- [MLflow MCP Registry docs](https://mlflow.org/docs/latest/genai/mcp-registry/) -- Full entity reference and API surface.
+- [MLflow MCP Server docs](https://mlflow.org/docs/latest/genai/mcp/) -- The other half of MLflow's MCP story.

--- a/website/cookbook/2026-09-05-mlflow-mcp-registry/mlflow_mcp_registry.svg
+++ b/website/cookbook/2026-09-05-mlflow-mcp-registry/mlflow_mcp_registry.svg
@@ -1,0 +1,145 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 680" width="1200" height="680" font-family="'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1a2e"/>
+      <stop offset="100%" style="stop-color:#16213e"/>
+    </linearGradient>
+    <linearGradient id="registryGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#533483"/>
+      <stop offset="100%" style="stop-color:#6c3d9e"/>
+    </linearGradient>
+    <linearGradient id="customGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f3460"/>
+      <stop offset="100%" style="stop-color:#2471a3"/>
+    </linearGradient>
+    <linearGradient id="externalGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#e97c00"/>
+      <stop offset="100%" style="stop-color:#f5a623"/>
+    </linearGradient>
+    <linearGradient id="registryStrip" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#bb86fc;stop-opacity:0.15"/>
+      <stop offset="50%" style="stop-color:#bb86fc;stop-opacity:0.05"/>
+      <stop offset="100%" style="stop-color:#bb86fc;stop-opacity:0.15"/>
+    </linearGradient>
+    <filter id="softShadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="680" fill="url(#bgGrad)" rx="16"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.03">
+    <line x1="0" y1="120" x2="1200" y2="120" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="240" x2="1200" y2="240" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="360" x2="1200" y2="360" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="480" x2="1200" y2="480" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="600" x2="1200" y2="600" stroke="#fff" stroke-width="1"/>
+    <line x1="300" y1="0" x2="300" y2="680" stroke="#fff" stroke-width="1"/>
+    <line x1="600" y1="0" x2="600" y2="680" stroke="#fff" stroke-width="1"/>
+    <line x1="900" y1="0" x2="900" y2="680" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Decorative -->
+  <circle cx="80" cy="140" r="40" fill="#533483" opacity="0.08"/>
+  <circle cx="1120" cy="560" r="55" fill="#f5a623" opacity="0.06"/>
+  <circle cx="150" cy="600" r="30" fill="#2471a3" opacity="0.06"/>
+  <circle cx="1050" cy="120" r="35" fill="#bb86fc" opacity="0.07"/>
+  <circle cx="920" cy="620" r="3" fill="#f5a623" opacity="0.15"/>
+  <circle cx="300" cy="100" r="3" fill="#bb86fc" opacity="0.15"/>
+
+  <!-- Title -->
+  <text x="600" y="44" fill="#fff" font-size="13" font-weight="600" text-anchor="middle" opacity="0.35" letter-spacing="3">THE MLflow MCP REGISTRY</text>
+  <g transform="translate(390, 60)">
+    <rect x="0" y="0" width="100" height="22" rx="11" fill="#2ecc71" opacity="0.15"/>
+    <text x="50" y="15" fill="#2ecc71" font-size="10" font-weight="600" text-anchor="middle">MLflow 3.15</text>
+    <rect x="115" y="0" width="110" height="22" rx="11" fill="#bb86fc" opacity="0.15"/>
+    <text x="170" y="15" fill="#bb86fc" font-size="10" font-weight="600" text-anchor="middle">MCP Registry</text>
+    <rect x="240" y="0" width="130" height="22" rx="11" fill="#4fc3f7" opacity="0.15"/>
+    <text x="305" y="15" fill="#4fc3f7" font-size="10" font-weight="600" text-anchor="middle">auto-discovery</text>
+  </g>
+
+  <!-- backdrop -->
+  <rect x="30" y="100" width="1140" height="560" rx="18" fill="url(#registryStrip)" stroke="#bb86fc" stroke-width="1" stroke-opacity="0.14"/>
+  <text x="55" y="126" fill="#bb86fc" font-size="11" font-weight="600" opacity="0.7" letter-spacing="2">CATALOG MCP SERVERS &amp; SNAPSHOT THEIR TOOLS  (stored in the MLflow tracking server)</text>
+
+  <!-- Registry central node -->
+  <g filter="url(#softShadow)">
+    <rect x="450" y="150" width="300" height="100" rx="18" fill="url(#registryGrad)"/>
+  </g>
+  <g transform="translate(486, 200)">
+    <rect x="-16" y="-16" width="32" height="32" rx="6" fill="none" stroke="#fff" stroke-width="2" opacity="0.9"/>
+    <line x1="-16" y1="-6" x2="16" y2="-6" stroke="#fff" stroke-width="1.6" opacity="0.6"/>
+    <line x1="-16" y1="4" x2="16" y2="4" stroke="#fff" stroke-width="1.6" opacity="0.6"/>
+    <circle cx="-8" cy="-11" r="1.8" fill="#fff"/>
+    <circle cx="-8" cy="-1" r="1.8" fill="#fff"/>
+    <circle cx="-8" cy="9" r="1.8" fill="#fff"/>
+  </g>
+  <text x="520" y="192" fill="#fff" font-size="20" font-weight="700">MCP Registry</text>
+  <text x="520" y="216" fill="#e8dcff" font-size="12" opacity="0.85">register &#183; version &#183; discover &#183; alias</text>
+
+  <!-- Entity pills -->
+  <g transform="translate(360, 268)">
+    <rect x="0" y="0" width="150" height="26" rx="13" fill="#bb86fc" opacity="0.16" stroke="#bb86fc" stroke-width="1" stroke-opacity="0.3"/>
+    <text x="75" y="17" fill="#d7b8ff" font-size="11" font-weight="600" text-anchor="middle">MCPServer</text>
+    <rect x="165" y="0" width="220" height="26" rx="13" fill="#bb86fc" opacity="0.16" stroke="#bb86fc" stroke-width="1" stroke-opacity="0.3"/>
+    <text x="275" y="17" fill="#d7b8ff" font-size="11" font-weight="600" text-anchor="middle">MCPServerVersion (+ tools snapshot)</text>
+    <rect x="410" y="0" width="180" height="26" rx="13" fill="#bb86fc" opacity="0.16" stroke="#bb86fc" stroke-width="1" stroke-opacity="0.3"/>
+    <text x="500" y="17" fill="#d7b8ff" font-size="11" font-weight="600" text-anchor="middle">MCPAccessEndpoint</text>
+  </g>
+
+  <!-- Status lifecycle chip -->
+  <g transform="translate(430, 312)">
+    <rect x="0" y="0" width="340" height="26" rx="13" fill="#48c9b0" opacity="0.12" stroke="#48c9b0" stroke-width="1" stroke-opacity="0.3"/>
+    <text x="170" y="17" fill="#7ff0da" font-size="11" font-weight="600" text-anchor="middle">status:  draft  →  active  →  deprecated  →  deleted</text>
+  </g>
+
+  <!-- Arrow custom -> registry -->
+  <path d="M300 470 Q380 380 470 250" stroke="#4fc3f7" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.6"/>
+  <polygon points="471,248 469,262 459,255" fill="#4fc3f7" opacity="0.6"/>
+  <rect x="300" y="392" width="150" height="22" rx="11" fill="#4fc3f7" opacity="0.15"/>
+  <text x="375" y="407" fill="#9fdcff" font-size="11" font-weight="600" text-anchor="middle">register_mcp_server</text>
+
+  <!-- Arrow external -> registry -->
+  <path d="M900 470 Q820 380 730 250" stroke="#f5a623" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.6"/>
+  <polygon points="728,248 742,255 731,263" fill="#f5a623" opacity="0.6"/>
+  <rect x="748" y="392" width="160" height="22" rx="11" fill="#f5a623" opacity="0.15"/>
+  <text x="828" y="407" fill="#ffd591" font-size="11" font-weight="600" text-anchor="middle">register + auto-discover</text>
+
+  <!-- Custom MCP Server -->
+  <g filter="url(#softShadow)">
+    <rect x="80" y="470" width="320" height="160" rx="16" fill="url(#customGrad)"/>
+  </g>
+  <text x="108" y="502" fill="#fff" font-size="17" font-weight="700">Custom MCP Server</text>
+  <text x="108" y="522" fill="#9fdcff" font-size="11.5" font-family="'SFMono-Regular', Consolas, monospace">io.github.example/orders-analytics</text>
+  <text x="108" y="539" fill="#cfe8ff" font-size="10.5" opacity="0.8">SQLite orders &#183; query your data via SQL</text>
+  <g transform="translate(105, 550)">
+    <rect x="0" y="0" width="74" height="22" rx="11" fill="#fff" opacity="0.16"/>
+    <text x="37" y="15" fill="#fff" font-size="11" font-weight="600" text-anchor="middle">run_sql</text>
+    <rect x="82" y="0" width="104" height="22" rx="11" fill="#fff" opacity="0.16"/>
+    <text x="134" y="15" fill="#fff" font-size="11" font-weight="600" text-anchor="middle">top_products</text>
+  </g>
+  <g transform="translate(105, 582)">
+    <rect x="0" y="0" width="52" height="20" rx="10" fill="#2ecc71" opacity="0.25"/>
+    <text x="26" y="14" fill="#7fe8b0" font-size="10" font-weight="600" text-anchor="middle">v1.0.0</text>
+    <rect x="60" y="0" width="52" height="20" rx="10" fill="#2ecc71" opacity="0.25"/>
+    <text x="86" y="14" fill="#7fe8b0" font-size="10" font-weight="600" text-anchor="middle">v1.1.0</text>
+    <rect x="120" y="0" width="118" height="20" rx="10" fill="#f5a623" opacity="0.22"/>
+    <text x="179" y="14" fill="#ffd591" font-size="10" font-weight="600" text-anchor="middle">alias: production</text>
+  </g>
+
+  <!-- External MCP Server -->
+  <g filter="url(#softShadow)">
+    <rect x="800" y="470" width="320" height="160" rx="16" fill="url(#externalGrad)"/>
+  </g>
+  <text x="828" y="502" fill="#fff" font-size="17" font-weight="700">External MCP Server</text>
+  <text x="828" y="522" fill="#3b2600" font-size="11.5" font-weight="600" font-family="'SFMono-Regular', Consolas, monospace">com.deepwiki/mcp</text>
+  <text x="828" y="539" fill="#3b2600" font-size="10.5" font-weight="500" opacity="0.85">public remote &#183; ask about GitHub repos</text>
+  <g transform="translate(825, 550)">
+    <rect x="0" y="0" width="98" height="22" rx="11" fill="#fff" opacity="0.28"/>
+    <text x="49" y="15" fill="#3b2600" font-size="11" font-weight="600" text-anchor="middle">ask_question</text>
+    <rect x="106" y="0" width="118" height="22" rx="11" fill="#fff" opacity="0.28"/>
+    <text x="165" y="15" fill="#3b2600" font-size="11" font-weight="600" text-anchor="middle">read_wiki_contents</text>
+  </g>
+  <text x="828" y="600" fill="#3b2600" font-size="10.5" font-weight="500" opacity="0.85">remote: https://mcp.deepwiki.com/mcp</text>
+</svg>

--- a/website/cookbook/2026-09-05-mlflow-mcp-server/index.md
+++ b/website/cookbook/2026-09-05-mlflow-mcp-server/index.md
@@ -1,0 +1,386 @@
+---
+title: "MLflow MCP Server: Debug, Analyze, and Annotate Traces from Any AI Assistant"
+slug: mlflow-mcp-server
+description: "Expose MLflow as MCP tools, then use them to debug failures, analyze latency, log feedback, and wire the server into Claude, VS Code, and Cursor."
+tags: [tracing, mcp, tools, observability]
+date: 2026-09-05T12:00:00
+---
+
+Turn MLflow into a set of tools an AI assistant can call. Start the MLflow MCP Server, connect a client over stdio, and use the built-in tools to debug failing traces, analyze latency, log quality feedback, and clean up -- then register the server so Claude, VS Code, or Cursor can do the same from natural language.
+
+<!-- truncate -->
+
+![Clients (Claude, VS Code, Cursor, or a programmatic fastmcp client) call MLflow operations as MCP tools over stdio, served by `mlflow mcp run` and scoped by MLFLOW_MCP_TOOLS.](./mlflow_mcp_server.svg)
+
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open standard that lets AI assistants call external _tools_ through a uniform interface. The MLflow MCP Server -- `mlflow mcp run` -- exposes MLflow operations (searching traces, reading a trace, logging feedback, managing experiments and runs) as MCP tools. Point an assistant at it and it can observe and act on your MLflow data for you: "find the failed traces from the last hour," "show me the slowest ones," "log a relevance score on this trace."
+
+:::tip[Prerequisites]
+
+```bash
+pip install "mlflow[mcp]>=3.5.1"
+```
+
+Start a tracking server in a separate terminal and leave it running:
+
+```bash
+mlflow server --backend-store-uri sqlite:///mlflow.db --port 5000
+```
+
+:::
+
+## What You'll Build
+
+Point MLflow at your running server, pick an experiment, and confirm the version supports the MCP Server.
+
+```python
+import os
+import sys
+import mlflow
+from packaging.version import Version
+
+TRACKING_URI = "http://localhost:5000"
+os.environ["MLFLOW_TRACKING_URI"] = TRACKING_URI  # the MCP server subprocess reads this
+mlflow.set_tracking_uri(TRACKING_URI)
+
+experiment = mlflow.set_experiment("mcp-server-demo")
+
+assert Version(mlflow.__version__) >= Version("3.5.1"), (
+    f"The MLflow MCP Server needs MLflow >= 3.5.1 (found {mlflow.__version__})."
+)
+print(f"Experiment: {experiment.name} (id={experiment.experiment_id})")
+# Example: Experiment: mcp-server-demo (id=1)
+```
+
+### Generate Sample Traces to Query
+
+So the tools have realistic data to act on, generate a handful of traces an assistant would triage. These use plain `@mlflow.trace` functions -- no LLM or API key required -- each tagged with a `span_type` so it is labeled by the kind of work it represents. The set is chosen to cover the main things tracing captures: a healthy `LLM` trace, a slow `TASK`, a failing `TOOL`, a multi-span RAG `CHAIN`, a tagged production trace, and a chat trace that records token usage.
+
+```python
+import time
+from mlflow.entities import SpanType
+
+
+@mlflow.trace(span_type=SpanType.LLM)
+def answer(question: str) -> str:
+    """A healthy (OK) trace tagged as an LLM span. We attach feedback to one later."""
+    return f"Here is a helpful answer to: {question}"
+
+
+@mlflow.trace(span_type=SpanType.TASK)
+def slow_report() -> str:
+    """An OK but deliberately slow (~1.3s) trace for the latency workflow."""
+    time.sleep(1.3)
+    return "generated a large report"
+
+
+@mlflow.trace(span_type=SpanType.TOOL)
+def flaky_tool() -> str:
+    """Raises on purpose so MLflow records the trace with ERROR status."""
+    raise RuntimeError("simulated downstream failure")
+
+
+@mlflow.trace(span_type=SpanType.RETRIEVER)
+def retrieve(question: str) -> list[str]:
+    """A RETRIEVER child of the RAG trace below."""
+    return ["doc: MLflow Tracing records spans", "doc: spans nest into a trace"]
+
+
+@mlflow.trace(span_type=SpanType.LLM)
+def generate(question: str, docs: list[str]) -> str:
+    """An LLM child of the RAG trace."""
+    return f"Based on {len(docs)} documents: here is the answer to '{question}'."
+
+
+@mlflow.trace(span_type=SpanType.CHAIN)
+def rag_answer(question: str) -> str:
+    """A small RAG pipeline: a CHAIN parent with RETRIEVER and LLM children."""
+    docs = retrieve(question)
+    return generate(question, docs)
+
+
+@mlflow.trace(span_type=SpanType.LLM)
+def production_query(question: str) -> str:
+    """Attaches custom tags so we can filter by deployment context."""
+    mlflow.update_current_trace(tags={"environment": "production", "user_tier": "premium"})
+    return f"Production answer to: {question}"
+
+
+@mlflow.trace(span_type=SpanType.CHAT_MODEL)
+def chat_with_usage(question: str) -> str:
+    """Records token usage on its span; rolls up to trace.info.token_usage."""
+    span = mlflow.get_current_active_span()
+    span.set_attribute(
+        "mlflow.chat.tokenUsage",
+        {"input_tokens": 42, "output_tokens": 58, "total_tokens": 100},
+    )
+    return f"Chat answer to: {question}"
+```
+
+Run them, flushing the async exporter so the traces are immediately queryable, and keep a few trace ids for later.
+
+```python
+# A healthy trace we'll attach feedback to later.
+answer("What is MLflow Tracing?")
+mlflow.flush_trace_async_logging()
+ok_trace_id = mlflow.get_last_active_trace_id()
+
+# More OK / slow / error traces.
+answer("How do I evaluate an agent?")
+slow_report()
+try:
+    flaky_tool()
+except RuntimeError:
+    pass  # the failure is captured in the trace as an ERROR
+
+# A nested RAG trace -- capture its id to inspect the span hierarchy later.
+rag_answer("How does MLflow tracing work?")
+mlflow.flush_trace_async_logging()
+rag_trace_id = mlflow.get_last_active_trace_id()
+
+# A tagged production trace and a chat trace with token usage.
+production_query("What is my order status?")
+chat_with_usage("Summarize the MCP docs.")
+mlflow.flush_trace_async_logging()
+chat_trace_id = mlflow.get_last_active_trace_id()
+
+print(f"Seeded 7 traces in experiment {experiment.experiment_id}")
+# Example: Seeded 7 traces in experiment 1
+```
+
+### Connect an MCP Client and List the Available MLflow Tools
+
+`mlflow mcp run` speaks MCP over **stdio**: the client launches it as a subprocess and the two exchange JSON-RPC messages over the child's standard I/O pipes -- plain pipe-based IPC, no network socket, so the server lives only as long as the client.
+
+The `MLFLOW_MCP_TOOLS` environment variable controls which tool _categories_ are exposed. Smaller tool lists mean less token overhead for an assistant.
+
+| `MLFLOW_MCP_TOOLS`  | Categories                               | Tool count |
+| ------------------- | ---------------------------------------- | ---------- |
+| `genai` _(default)_ | traces, scorers, experiments, runs       | 26         |
+| `ml`                | experiments, runs, models, deployments   | 32         |
+| `all`               | everything above                         | 45         |
+| comma-separated     | a custom subset, e.g. `"traces,scorers"` | varies     |
+
+Launch the server with the default `genai` toolset and list what it exposes. Define a small `mcp(...)` helper that opens a client, calls one tool, and returns its text -- reused throughout.
+
+```python
+import asyncio
+import nest_asyncio
+from fastmcp import Client
+from fastmcp.client.transports import StdioTransport
+
+# In a notebook or REPL an event loop is already running; nest_asyncio lets us
+# call asyncio.run() inside it. Omit this line (and the import) in a plain .py script.
+nest_asyncio.apply()
+
+
+def mcp_transport(tools: str = "genai") -> StdioTransport:
+    """Launch `mlflow mcp run` over stdio with a chosen MLFLOW_MCP_TOOLS set."""
+    return StdioTransport(
+        command=sys.executable,  # `python -m mlflow`; no dependency on `mlflow` being on PATH
+        args=["-m", "mlflow", "mcp", "run"],
+        env={**os.environ, "MLFLOW_MCP_TOOLS": tools},
+    )
+
+
+def mcp(tool: str, arguments: dict | None = None, tools: str = "genai") -> str:
+    """Call one MLflow MCP tool and return its text output."""
+    async def _call():
+        async with Client(mcp_transport(tools)) as client:
+            result = await client.call_tool(tool, arguments or {})
+            return result.content[0].text
+
+    return asyncio.run(_call())
+
+
+async def _list_tools():
+    async with Client(mcp_transport("genai")) as client:
+        return await client.list_tools()
+
+
+tools = asyncio.run(_list_tools())
+print(f"{len(tools)} tools exposed with MLFLOW_MCP_TOOLS=genai")
+# Example: 26 tools exposed with MLFLOW_MCP_TOOLS=genai
+# search_traces, get_trace, delete_traces, set_trace_tag, log_trace_feedback,
+# get_trace_assessment, evaluate_traces, list_scorers, create_experiment,
+# search_experiments, list_runs, create_run, link_traces_to_run, ...
+```
+
+Each workflow below is a single real tool call. In practice an assistant issues these for you from natural language -- the prompt it would receive is shown above each call.
+
+### Find Failed Traces with `search_traces`
+
+> _"Find the failed traces in my experiment."_
+
+`search_traces` accepts a `filter_string` (the same grammar as the MLflow UI) and an optional `extract_fields` to return only the columns you care about, keeping responses small. Its output is a compact table.
+
+```python
+print(mcp("search_traces", {
+    "experiment_id": experiment.experiment_id,
+    "filter_string": "status = 'ERROR'",
+    "extract_fields": "info.trace_id,info.state,info.request_preview",
+}))
+# Example:
+# info.trace_id                        info.state    info.request_preview
+# -----------------------------------  ------------  --------------------
+# tr-f3912f13ffa051dd0cab558a42b32989  ERROR         {}
+```
+
+### Find Slow Traces by Execution Time
+
+> _"Show me the traces that took longer than a second."_
+
+Filter on `execution_time_ms` and pull just the duration field.
+
+```python
+print(mcp("search_traces", {
+    "experiment_id": experiment.experiment_id,
+    "filter_string": "execution_time_ms > 1000",
+    "extract_fields": "info.trace_id,info.execution_duration_ms",
+}))
+# Example:
+# info.trace_id                        info.execution_duration_ms
+# -----------------------------------  --------------------------
+# tr-0cc558dc15db559253da5d9b4917f8ce  1.3s
+```
+
+### Log a Quality Score on a Trace with `log_trace_feedback`
+
+> _"Log a relevance score of 0.9 on this trace, with a rationale."_
+
+`log_trace_feedback` records an assessment on a trace -- ideal for human review or LLM-judge scores. The `value` is passed as a JSON-encoded string. Read it back with `get_trace`, selecting only the assessments; `get_trace` returns JSON.
+
+```python
+print(mcp("log_trace_feedback", {
+    "trace_id": ok_trace_id,
+    "name": "relevance",
+    "value": "0.9",              # JSON-encoded value
+    "source_type": "HUMAN",
+    "source_id": "reviewer@example.com",
+    "rationale": "Answer is on-topic and accurate.",
+}))
+# Example: Logged feedback 'relevance' to trace tr-a3a3... Assessment ID: a-f2f8...
+
+print(mcp("get_trace", {
+    "trace_id": ok_trace_id,
+    "extract_fields": "info.assessments.*",
+}))
+# Example (abridged):
+# {"info": {"assessments": [{"assessment_name": "relevance",
+#   "source": {"source_type": "HUMAN", "source_id": "reviewer@example.com"},
+#   "feedback": {"value": 0.9}, "rationale": "Answer is on-topic and accurate."}]}}
+```
+
+### Filter by Tag, Inspect Span Hierarchy, and Read Token Usage
+
+The `genai` toolset also manages experiments and runs (the `ml` set adds models and deployments). List the experiments on the server:
+
+```python
+print(mcp("search_experiments", {"max_results": 5}))
+```
+
+The three richer traces seeded earlier surface more of what tracing captures -- each one tool call away. **Filter by tag** to find traces that came from production:
+
+```python
+print(mcp("search_traces", {
+    "experiment_id": experiment.experiment_id,
+    "filter_string": "tags.environment = 'production'",
+    "extract_fields": "info.trace_id,info.tags.environment,info.tags.user_tier",
+}))
+# Example:
+# info.trace_id                        info.tags.environment    info.tags.user_tier
+# -----------------------------------  -----------------------  -------------------
+# tr-e7415d0d5886aeab90c82dc0b13558d7  production               premium
+```
+
+**Reveal the span hierarchy** of the RAG trace -- `parent_span_id` links the RETRIEVER and LLM children to their `CHAIN` parent (`rag_answer`, the root, has no parent):
+
+```python
+print(mcp("get_trace", {
+    "trace_id": rag_trace_id,
+    "extract_fields": "data.spans.*.name,data.spans.*.span_id,data.spans.*.parent_span_id",
+}))
+# Example (abridged): rag_answer (root) -> retrieve, generate (both parented to rag_answer)
+```
+
+**Read token usage** -- the chat span records token counts under the standard `mlflow.chat.tokenUsage` attribute. The field selector can return the whole `attributes` map but can't isolate the dotted key, and attribute values come back JSON-encoded, so grab `data.spans.*.attributes` and decode the one you want.
+
+```python
+import json
+
+detail = mcp("get_trace", {
+    "trace_id": chat_trace_id,
+    "extract_fields": "data.spans.*.attributes",
+})
+
+for span in json.loads(detail)["data"]["spans"]:
+    raw_usage = span.get("attributes", {}).get("mlflow.chat.tokenUsage")
+    if raw_usage:
+        print(json.loads(raw_usage))
+        # Example: {'input_tokens': 42, 'output_tokens': 58, 'total_tokens': 100}
+```
+
+If you are already in Python, the SDK exposes a tidier `mlflow.get_trace(id).info.token_usage` accessor. The `get_trace` tool exists so an _assistant_, which only has the MCP tools, can reach the same data.
+
+### Add the MLflow MCP Server to Claude, VS Code, and Cursor
+
+You normally don't hand-write a client. Register the server once and its tools become available to your assistant. Set `MLFLOW_TRACKING_URI` to your server (`http://localhost:5000`, a remote URL, or `databricks` with `DATABRICKS_HOST` / `DATABRICKS_TOKEN`).
+
+**Claude Code / Claude Desktop** (CLI):
+
+```bash
+claude mcp add mlflow-mcp -e MLFLOW_TRACKING_URI=http://localhost:5000 \
+  -- uv run --with "mlflow[mcp]>=3.5.1" mlflow mcp run
+```
+
+**Claude -- project-level `.mcp.json`** (VS Code uses the same shape under a `servers` key; Cursor under `.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "mlflow-mcp": {
+      "command": "uv",
+      "args": ["run", "--with", "mlflow[mcp]>=3.5.1", "mlflow", "mcp", "run"],
+      "env": {
+        "MLFLOW_TRACKING_URI": "http://localhost:5000",
+        "MLFLOW_MCP_TOOLS": "genai"
+      }
+    }
+  }
+}
+```
+
+Then just ask, in natural language:
+
+- _"Find all failed traces in experiment 1 from the last hour."_
+- _"Show me the slowest traces with execution time over 1 second."_
+- _"Log a relevance score of 0.85 for trace tr-… with a rationale about accuracy."_
+
+### Delete Traces to Reset the Environment
+
+`delete_traces` accepts trace ids or a max timestamp. Delete this experiment's traces so the recipe stays re-runnable.
+
+```python
+import time
+
+print(mcp("delete_traces", {
+    "experiment_id": experiment.experiment_id,
+    "max_timestamp_millis": int(time.time() * 1000),
+}))
+# Example: Deleted 7 trace(s) from experiment 1.
+```
+
+## Results
+
+After completing this cookbook, you have:
+
+1. **A running MLflow MCP Server** -- started `mlflow mcp run` and driven it from a programmatic `fastmcp` client over stdio.
+2. **Scoped tools** -- controlled which tools are exposed with `MLFLOW_MCP_TOOLS` (`genai` / `ml` / `all` / a custom subset) to trim an assistant's token overhead.
+3. **Four real workflows** -- debugged failures (`search_traces` on `status='ERROR'`), analyzed latency (`execution_time_ms`), logged quality feedback (`log_trace_feedback` + `get_trace`), and cleaned up (`delete_traces`), using `extract_fields` to keep responses small.
+4. **Richer trace access** -- filtered by tag, revealed a span hierarchy, and read token usage through the same `get_trace` tool an assistant would use.
+5. **Assistant integration** -- registered the server with Claude, VS Code, and Cursor so the same operations run from natural language.
+
+## Next Steps
+
+- [MLflow MCP Server docs](https://mlflow.org/docs/latest/genai/mcp/) -- Full tool reference and configuration options.
+- [Search Traces Reference](https://mlflow.org/docs/latest/genai/tracing/search-traces) -- The complete `filter_string` grammar used above.
+- [Production Observability with MLflow Tracing](/cookbook/production-observability) -- Turn these queries into latency dashboards, error monitors, and alerts.

--- a/website/cookbook/2026-09-05-mlflow-mcp-server/mlflow_mcp_server.svg
+++ b/website/cookbook/2026-09-05-mlflow-mcp-server/mlflow_mcp_server.svg
@@ -1,0 +1,152 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 640" width="1200" height="640" font-family="'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1a2e"/>
+      <stop offset="100%" style="stop-color:#16213e"/>
+    </linearGradient>
+    <linearGradient id="mlflowGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e8449"/>
+      <stop offset="100%" style="stop-color:#27ae60"/>
+    </linearGradient>
+    <linearGradient id="clientGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#48c9b0"/>
+      <stop offset="100%" style="stop-color:#1abc9c"/>
+    </linearGradient>
+    <linearGradient id="storeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f3460"/>
+      <stop offset="100%" style="stop-color:#1a5276"/>
+    </linearGradient>
+    <linearGradient id="serverStrip" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#2ecc71;stop-opacity:0.15"/>
+      <stop offset="50%" style="stop-color:#2ecc71;stop-opacity:0.05"/>
+      <stop offset="100%" style="stop-color:#2ecc71;stop-opacity:0.15"/>
+    </linearGradient>
+    <filter id="softShadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="640" fill="url(#bgGrad)" rx="16"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.03">
+    <line x1="0" y1="120" x2="1200" y2="120" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="240" x2="1200" y2="240" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="360" x2="1200" y2="360" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="480" x2="1200" y2="480" stroke="#fff" stroke-width="1"/>
+    <line x1="300" y1="0" x2="300" y2="640" stroke="#fff" stroke-width="1"/>
+    <line x1="600" y1="0" x2="600" y2="640" stroke="#fff" stroke-width="1"/>
+    <line x1="900" y1="0" x2="900" y2="640" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Decorative circles -->
+  <circle cx="80" cy="130" r="40" fill="#27ae60" opacity="0.06"/>
+  <circle cx="1120" cy="540" r="55" fill="#4fc3f7" opacity="0.06"/>
+  <circle cx="1050" cy="110" r="35" fill="#48c9b0" opacity="0.07"/>
+  <circle cx="300" cy="90" r="3" fill="#27ae60" opacity="0.15"/>
+  <circle cx="920" cy="600" r="3" fill="#4fc3f7" opacity="0.15"/>
+
+  <!-- Title -->
+  <text x="600" y="44" fill="#fff" font-size="13" font-weight="600" text-anchor="middle" opacity="0.35" letter-spacing="3">THE MLflow MCP SERVER</text>
+  <g transform="translate(400, 60)">
+    <rect x="0" y="0" width="100" height="22" rx="11" fill="#2ecc71" opacity="0.15"/>
+    <text x="50" y="15" fill="#2ecc71" font-size="10" font-weight="600" text-anchor="middle">MLflow 3.15</text>
+    <rect x="115" y="0" width="70" height="22" rx="11" fill="#bb86fc" opacity="0.15"/>
+    <text x="150" y="15" fill="#bb86fc" font-size="10" font-weight="600" text-anchor="middle">MCP</text>
+    <rect x="200" y="0" width="90" height="22" rx="11" fill="#4fc3f7" opacity="0.15"/>
+    <text x="245" y="15" fill="#4fc3f7" font-size="10" font-weight="600" text-anchor="middle">FastMCP</text>
+    <rect x="305" y="0" width="90" height="22" rx="11" fill="#f5a623" opacity="0.15"/>
+    <text x="350" y="15" fill="#f5a623" font-size="10" font-weight="600" text-anchor="middle">stdio</text>
+  </g>
+
+  <!-- backdrop strip -->
+  <rect x="30" y="100" width="1140" height="230" rx="18" fill="url(#serverStrip)" stroke="#2ecc71" stroke-width="1" stroke-opacity="0.12"/>
+  <text x="55" y="126" fill="#2ecc71" font-size="11" font-weight="600" opacity="0.6" letter-spacing="2">$ mlflow mcp run  —  MLflow OPERATIONS AS TOOLS FOR AI ASSISTANTS</text>
+
+  <!-- MCP Clients -->
+  <g filter="url(#softShadow)">
+    <rect x="70" y="158" width="270" height="152" rx="16" fill="url(#clientGrad)"/>
+  </g>
+  <g transform="translate(108, 196)">
+    <circle cx="0" cy="0" r="13" fill="none" stroke="#fff" stroke-width="2.5"/>
+    <circle cx="0" cy="-5" r="5" fill="#fff"/>
+    <path d="M-10 9 c0-5.5 4.5-9.5 10-9.5 s10 4 10 9.5" fill="none" stroke="#fff" stroke-width="2.5" stroke-linecap="round"/>
+  </g>
+  <text x="135" y="200" fill="#fff" font-size="18" font-weight="700">MCP Clients</text>
+  <g transform="translate(95, 230)" fill="#fff">
+    <rect x="0" y="0" width="8" height="8" rx="2" opacity="0.6"/>
+    <text x="14" y="8" font-size="12" opacity="0.85">Claude Code / Desktop</text>
+    <rect x="0" y="24" width="8" height="8" rx="2" opacity="0.6"/>
+    <text x="14" y="32" font-size="12" opacity="0.85">VS Code &#183; Cursor</text>
+    <rect x="0" y="48" width="8" height="8" rx="2" opacity="0.6"/>
+    <text x="14" y="56" font-size="12" opacity="0.85">Programmatic (fastmcp)</text>
+  </g>
+
+  <!-- Arrow clients -> server -->
+  <line x1="340" y1="234" x2="458" y2="234" stroke="#48c9b0" stroke-width="3" stroke-linecap="round" opacity="0.75"/>
+  <polygon points="456,226 470,234 456,242" fill="#48c9b0" opacity="0.75"/>
+  <rect x="352" y="205" width="96" height="22" rx="11" fill="#48c9b0" opacity="0.15"/>
+  <text x="400" y="220" fill="#7ff0da" font-size="11" font-weight="600" text-anchor="middle">call tools</text>
+
+  <!-- MLflow MCP Server -->
+  <g filter="url(#softShadow)">
+    <rect x="470" y="158" width="360" height="152" rx="16" fill="url(#mlflowGrad)"/>
+  </g>
+  <text x="500" y="192" fill="#fff" font-size="19" font-weight="700">MLflow MCP Server</text>
+  <text x="500" y="213" fill="#eafaf1" font-size="12" font-weight="500" font-family="'SFMono-Regular', Consolas, monospace">mlflow mcp run</text>
+  <g transform="translate(492, 226)">
+    <rect x="0" y="0" width="104" height="22" rx="11" fill="#fff" opacity="0.18"/>
+    <text x="52" y="15" fill="#fff" font-size="11" font-weight="600" text-anchor="middle">search_traces</text>
+    <rect x="112" y="0" width="82" height="22" rx="11" fill="#fff" opacity="0.18"/>
+    <text x="153" y="15" fill="#fff" font-size="11" font-weight="600" text-anchor="middle">get_trace</text>
+    <rect x="210" y="0" width="118" height="22" rx="11" fill="#fff" opacity="0.18"/>
+    <text x="269" y="15" fill="#fff" font-size="11" font-weight="600" text-anchor="middle">log_trace_feedback</text>
+  </g>
+  <text x="500" y="276" fill="#eafaf1" font-size="11" opacity="0.85">MLFLOW_MCP_TOOLS = genai (26) &#124; ml (32) &#124; all (45)</text>
+  <text x="500" y="294" fill="#eafaf1" font-size="10.5" opacity="0.7">groups: traces &#183; scorers &#183; experiments &#183; runs &#183; models &#183; deployments</text>
+
+  <!-- Arrow server -> store -->
+  <line x1="830" y1="234" x2="948" y2="234" stroke="#4fc3f7" stroke-width="3" stroke-linecap="round" opacity="0.7"/>
+  <polygon points="946,226 960,234 946,242" fill="#4fc3f7" opacity="0.7"/>
+  <rect x="838" y="205" width="104" height="22" rx="11" fill="#4fc3f7" opacity="0.15"/>
+  <text x="890" y="220" fill="#9fdcff" font-size="11" font-weight="600" text-anchor="middle">read / write</text>
+
+  <!-- Tracking store -->
+  <g filter="url(#softShadow)">
+    <rect x="960" y="170" width="180" height="128" rx="14" fill="url(#storeGrad)"/>
+  </g>
+  <g transform="translate(1000, 208)">
+    <ellipse cx="0" cy="-9" rx="15" ry="6" fill="none" stroke="#4fc3f7" stroke-width="2"/>
+    <path d="M-15 -9 L-15 9" stroke="#4fc3f7" stroke-width="2"/>
+    <path d="M15 -9 L15 9" stroke="#4fc3f7" stroke-width="2"/>
+    <ellipse cx="0" cy="9" rx="15" ry="6" fill="none" stroke="#4fc3f7" stroke-width="2"/>
+    <line x1="-15" y1="0" x2="15" y2="0" stroke="#4fc3f7" stroke-width="1" opacity="0.4"/>
+  </g>
+  <text x="1028" y="206" fill="#fff" font-size="15" font-weight="700">MLflow</text>
+  <text x="1028" y="224" fill="#fff" font-size="15" font-weight="700">Tracking</text>
+  <text x="1050" y="262" fill="#9fdcff" font-size="11" text-anchor="middle" opacity="0.85">Traces</text>
+  <text x="1050" y="280" fill="#9fdcff" font-size="11" text-anchor="middle" opacity="0.85">Experiments &#183; Runs</text>
+
+  <!-- Capability chips (the 4 use cases) -->
+  <text x="55" y="392" fill="#fff" font-size="11" font-weight="600" opacity="0.4" letter-spacing="2">WHAT AN ASSISTANT CAN DO</text>
+  <g transform="translate(70, 410)">
+    <rect x="0" y="0" width="255" height="72" rx="14" fill="#e94560" opacity="0.12" stroke="#e94560" stroke-width="1" stroke-opacity="0.3"/>
+    <text x="20" y="30" fill="#ff6b81" font-size="14" font-weight="700">Debug failures</text>
+    <text x="20" y="52" fill="#fff" font-size="11" opacity="0.75">search_traces  status = 'ERROR'</text>
+
+    <rect x="278" y="0" width="255" height="72" rx="14" fill="#f39c12" opacity="0.12" stroke="#f39c12" stroke-width="1" stroke-opacity="0.3"/>
+    <text x="298" y="30" fill="#ffbe5c" font-size="14" font-weight="700">Analyze latency</text>
+    <text x="298" y="52" fill="#fff" font-size="11" opacity="0.75">search_traces  execution_time_ms &gt; N</text>
+
+    <rect x="556" y="0" width="255" height="72" rx="14" fill="#2ecc71" opacity="0.12" stroke="#2ecc71" stroke-width="1" stroke-opacity="0.3"/>
+    <text x="576" y="30" fill="#5fe0a0" font-size="14" font-weight="700">Log quality feedback</text>
+    <text x="576" y="52" fill="#fff" font-size="11" opacity="0.75">log_trace_feedback  +  get_trace</text>
+
+    <rect x="834" y="0" width="255" height="72" rx="14" fill="#bb86fc" opacity="0.12" stroke="#bb86fc" stroke-width="1" stroke-opacity="0.3"/>
+    <text x="854" y="30" fill="#d7b8ff" font-size="14" font-weight="700">Clean up data</text>
+    <text x="854" y="52" fill="#fff" font-size="11" opacity="0.75">delete_traces  by id / timestamp</text>
+  </g>
+
+  <!-- extract_fields note -->
+  <text x="600" y="530" fill="#fff" font-size="12" text-anchor="middle" opacity="0.55">search_traces &amp; get_trace support <tspan font-family="'SFMono-Regular', Consolas, monospace" fill="#9fdcff" opacity="0.9">extract_fields</tspan> to return only the fields you need</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds two new cookbooks covering MLflow's Model Context Protocol (MCP) support:

- **MLflow MCP Server: Debug, Analyze, and Annotate Traces from Any AI Assistant** (`/cookbook/mlflow-mcp-server`) — start `mlflow mcp run`, connect an MCP client over stdio, and use the built-in tools to find failed traces, analyze latency, log quality feedback, inspect span hierarchies and token usage, and clean up. Includes registering the server with Claude, VS Code, and Cursor.
- **How to Register, Version, and Discover MCP Servers with the MLflow MCP Registry** (`/cookbook/mlflow-mcp-registry`) — register a custom (orders-analytics) server and a third-party one (DeepWiki) with live tool auto-discovery, resolve access endpoints and call discovered tools, and manage versions and aliases.

Each cookbook ships with a hero SVG diagram.

## Notes

- Ordered so the MCP Server cookbook appears before the MCP Registry cookbook in the listing (via `date` frontmatter).
- Prose reviewed for typos, accuracy, and clarity; titles and section headings written to be answer-engine friendly.
- `npm run fmt` clean and `npm run build` succeeds locally; both pages verified serving at 200.

This pull request and its description were written by Isaac.