### PR TITLE
Update ambassador Awadelrahman M.A. Ahmed's role and company

### DIFF
--- a/website/src/pages/ambassadors.json
+++ b/website/src/pages/ambassadors.json
@@ -22,8 +22,8 @@
   [
     {
       "title": "Awadelrahman M.A. Ahmed",
-      "role": "Cloud Data and AI Architect",
-      "company": "REMA 1000",
+      "role": "Tribe Architect - Data, Analytics & AI",
+      "company": "Gjensidige",
       "img": "/img/ambassadors/Awadelrahman M. A. Ahmed.png"
     },
     {


### PR DESCRIPTION
## Summary

Updates the ambassador entry for **Awadelrahman M.A. Ahmed** on the Ambassadors page:

- **Role:** Cloud Data and AI Architect → **Tribe Architect - Data, Analytics & AI**
- **Company:** REMA 1000 → **Gjensidige**

## Verification

`npm run fmt` clean and `npm run build` succeeds locally; the `/ambassadors/` page renders the updated role and company (the old "REMA 1000" entry is gone).

This pull request and its description were written by Isaac.